### PR TITLE
feat: add `v4_base_actions_parser` module

### DIFF
--- a/src/entities/trade.rs
+++ b/src/entities/trade.rs
@@ -191,6 +191,7 @@ where
                     pool.tick_spacing,
                     pool.hooks,
                 )
+                .unwrap()
             });
         let pool_id_set = FxHashSet::from_iter(pool_ids);
         assert_eq!(num_pools, pool_id_set.len(), "POOLS_DUPLICATED");

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,11 +1,12 @@
 #[cfg(doc)]
 use crate::prelude::*;
 
+use alloy_sol_types::Error as SolError;
 use derive_more::From;
 use uniswap_sdk_core::error::Error as CoreError;
 use uniswap_v3_sdk::error::Error as V3Error;
 
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, From)]
+#[derive(Debug, From)]
 #[cfg_attr(feature = "std", derive(thiserror::Error))]
 pub enum Error {
     /// Thrown when an error occurs in the core library.
@@ -15,6 +16,14 @@ pub enum Error {
     /// Thrown when an error occurs in the v3 library.
     #[cfg_attr(feature = "std", error("{0}"))]
     V3(#[cfg_attr(not(feature = "std"), from)] V3Error),
+
+    /// Thrown when an error occurs in the sol types library.
+    #[cfg_attr(feature = "std", error("{0}"))]
+    Sol(#[cfg_attr(not(feature = "std"), from)] SolError),
+
+    /// Thrown when the action is not supported.
+    #[cfg_attr(feature = "std", error("Unsupported action {0}"))]
+    InvalidAction(u8),
 
     /// Thrown when the currency passed to [`get_path_currency`] is not one of the pool's
     /// currencies.

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -2,12 +2,12 @@ pub mod encode_route_to_path;
 pub mod path_currency;
 pub mod price_tick_conversions;
 pub mod sorts_before;
-// pub mod v4_base_actions_parser;
+pub mod v4_base_actions_parser;
 pub mod v4_planner;
 
 pub use encode_route_to_path::*;
 pub use path_currency::*;
 pub use price_tick_conversions::*;
 pub use sorts_before::*;
-// pub use v4_base_actions_parser::*;
+pub use v4_base_actions_parser::*;
 pub use v4_planner::*;

--- a/src/utils/v4_base_actions_parser.rs
+++ b/src/utils/v4_base_actions_parser.rs
@@ -1,0 +1,22 @@
+use crate::prelude::{Actions, ActionsParams, Error};
+use alloy_primitives::Bytes;
+use alloy_sol_types::SolType;
+use core::iter::zip;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct V4RouterCall {
+    pub actions: Vec<Actions>,
+}
+
+#[inline]
+pub fn parse_calldata(calldata: &Bytes) -> Result<V4RouterCall, Error> {
+    let ActionsParams { actions, params } =
+        ActionsParams::abi_decode(calldata.iter().as_slice(), true)?;
+    let mut res = V4RouterCall {
+        actions: Vec::with_capacity(actions.len()),
+    };
+    for (command, data) in zip(actions, params) {
+        res.actions.push(Actions::abi_decode(command, &data)?);
+    }
+    Ok(res)
+}

--- a/src/utils/v4_planner.rs
+++ b/src/utils/v4_planner.rs
@@ -73,6 +73,32 @@ impl Actions {
         }
         .into()
     }
+
+    #[inline]
+    pub fn abi_decode(command: u8, data: &Bytes) -> Result<Self, Error> {
+        let data = data.iter().as_slice();
+        Ok(match command {
+            0x00 => Self::INCREASE_LIQUIDITY(IncreaseLiquidityParams::abi_decode(data, true)?),
+            0x01 => Self::DECREASE_LIQUIDITY(DecreaseLiquidityParams::abi_decode(data, true)?),
+            0x02 => Self::MINT_POSITION(MintPositionParams::abi_decode(data, true)?),
+            0x03 => Self::BURN_POSITION(BurnPositionParams::abi_decode(data, true)?),
+            0x04 => Self::SWAP_EXACT_IN_SINGLE(SwapExactInSingleParams::abi_decode(data, true)?),
+            0x05 => Self::SWAP_EXACT_IN(SwapExactInParams::abi_decode(data, true)?),
+            0x06 => Self::SWAP_EXACT_OUT_SINGLE(SwapExactOutSingleParams::abi_decode(data, true)?),
+            0x07 => Self::SWAP_EXACT_OUT(SwapExactOutParams::abi_decode(data, true)?),
+            0x09 => Self::SETTLE(SettleParams::abi_decode(data, true)?),
+            0x10 => Self::SETTLE_ALL(SettleAllParams::abi_decode(data, true)?),
+            0x11 => Self::SETTLE_PAIR(SettlePairParams::abi_decode(data, true)?),
+            0x12 => Self::TAKE(TakeParams::abi_decode(data, true)?),
+            0x13 => Self::TAKE_ALL(TakeAllParams::abi_decode(data, true)?),
+            0x14 => Self::TAKE_PORTION(TakePortionParams::abi_decode(data, true)?),
+            0x15 => Self::TAKE_PAIR(TakePairParams::abi_decode(data, true)?),
+            0x16 => Self::SETTLE_TAKE_PAIR(SettleTakePairParams::abi_decode(data, true)?),
+            0x17 => Self::CLOSE_CURRENCY(CloseCurrencyParams::abi_decode(data, true)?),
+            0x19 => Self::SWEEP(SweepParams::abi_decode(data, true)?),
+            _ => return Err(Error::InvalidAction(command)),
+        })
+    }
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]


### PR DESCRIPTION
Uncommented and enabled `v4_base_actions_parser` in utils. Introduced new `abi_decode` function in `v4_planner`. Updated error handling to include new `SolError` and `InvalidAction`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced trade execution and comparison logic, prioritizing trades with fewer hops.
	- New methods for creating trades based on input/output amounts and routes.
	- Introduced a new module for parsing calldata with the `V4RouterCall` struct and `parse_calldata` function.
	- Added decoding capability to the `Actions` enum with the `abi_decode` method.

- **Bug Fixes**
	- Improved error handling for insufficient liquidity scenarios and unsupported actions.

- **Documentation**
	- Updated error messages for better granularity in error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->