### PR TITLE
refactor: replace `create_action` with direct method calls on `Actions`

### DIFF
--- a/src/utils/v4_planner.rs
+++ b/src/utils/v4_planner.rs
@@ -110,9 +110,8 @@ pub struct V4Planner {
 impl V4Planner {
     #[inline]
     pub fn add_action(&mut self, action: &Actions) {
-        let action = create_action(action);
-        self.actions.push(action.action);
-        self.params.push(action.encoded_input);
+        self.actions.push(action.command());
+        self.params.push(action.abi_encode());
     }
 
     #[inline]
@@ -222,18 +221,6 @@ fn currency_address(currency: &impl BaseCurrency) -> Address {
         Address::ZERO
     } else {
         currency.wrapped().address()
-    }
-}
-
-struct RouterAction {
-    action: u8,
-    encoded_input: Bytes,
-}
-
-fn create_action(action: &Actions) -> RouterAction {
-    RouterAction {
-        action: action.command(),
-        encoded_input: action.abi_encode(),
     }
 }
 


### PR DESCRIPTION
Removed the `create_action` function and modified `add_action` to call methods directly on the `Actions` object. This reduces redundancy and simplifies the code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified the process of adding actions to the V4Planner by removing unnecessary abstractions.
	- Enhanced efficiency by directly pushing results into action vectors, eliminating the need for an intermediate struct and function.
- **Bug Fixes**
	- No changes affecting existing functionality; error handling and control flow remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->