### PR TITLE
test: add unit tests for `Pool`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ thiserror = { version = "1.0", optional = true }
 uniswap-sdk-core = "3.0.0"
 uniswap-v3-sdk = "2.4.0"
 
+[dev-dependencies]
+once_cell = "1.20.2"
+
 [features]
 default = []
 std = ["thiserror", "uniswap-sdk-core/std", "uniswap-v3-sdk/std"]

--- a/src/entities/trade.rs
+++ b/src/entities/trade.rs
@@ -703,7 +703,7 @@ where
                     currency_amount_in.clone(),
                     TradeType::ExactInput,
                 )?;
-                sorted_insert(best_trades, trade, max_num_results, trade_comparator)?;
+                sorted_insert(best_trades, trade, max_num_results, trade_comparator);
             } else if max_hops > 1 && pools.len() > 1 {
                 let pools_excluding_this_pool = pools[..i]
                     .iter()
@@ -804,7 +804,7 @@ where
                     currency_amount_out.clone(),
                     TradeType::ExactOutput,
                 )?;
-                sorted_insert(best_trades, trade, max_num_results, trade_comparator)?;
+                sorted_insert(best_trades, trade, max_num_results, trade_comparator);
             } else if max_hops > 1 && pools.len() > 1 {
                 let pools_excluding_this_pool = pools[..i]
                     .iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,9 @@ pub mod utils;
 
 pub use uniswap_v3_sdk::multicall;
 
+#[cfg(test)]
+mod tests;
+
 pub mod prelude {
     pub use crate::{abi::*, entities::*, error::*, multicall::*, utils::*};
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,0 +1,52 @@
+use crate::entities::Pool;
+use once_cell::sync::Lazy;
+use uniswap_sdk_core::{prelude::*, token};
+use uniswap_v3_sdk::{constants::FeeAmount, prelude::encode_sqrt_ratio_x96};
+
+pub(crate) static ETHER: Lazy<Ether> = Lazy::new(|| Ether::on_chain(1));
+pub(crate) static WETH: Lazy<Token> = Lazy::new(|| ETHER.wrapped().clone());
+pub(crate) static USDC: Lazy<Token> = Lazy::new(|| {
+    token!(
+        1,
+        "A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+        6,
+        "USDC",
+        "USD Coin"
+    )
+});
+pub(crate) static DAI: Lazy<Token> = Lazy::new(|| {
+    token!(
+        1,
+        "6B175474E89094C44Da98b954EedeAC495271d0F",
+        18,
+        "DAI",
+        "DAI Stablecoin"
+    )
+});
+
+pub(crate) static USDC_DAI: Lazy<Pool> = Lazy::new(|| {
+    Pool::new(
+        Currency::Token(USDC.clone()),
+        Currency::Token(DAI.clone()),
+        FeeAmount::LOWEST.into(),
+        10,
+        Address::ZERO,
+        encode_sqrt_ratio_x96(1, 1),
+        0,
+    )
+    .unwrap()
+});
+pub(crate) static DAI_USDC: Lazy<Pool> = Lazy::new(|| {
+    Pool::new(
+        Currency::Token(DAI.clone()),
+        Currency::Token(USDC.clone()),
+        FeeAmount::LOWEST.into(),
+        10,
+        Address::ZERO,
+        encode_sqrt_ratio_x96(1, 1),
+        0,
+    )
+    .unwrap()
+});
+
+pub(crate) const ONE_ETHER: u128 = 1_000_000_000_000_000_000;


### PR DESCRIPTION
Introduced a new test module for the `Pool` entity, including various test cases to cover constructor, key generation, id retrieval, and swap functionality. Also added `once_cell` dependency for lazy statics in tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new development dependency for improved testing capabilities.
	- Enhanced flexibility in the `Pool` struct methods to support various tick spacing types.
	- Introduced new test coverage for the `Pool` struct, validating its functionality under different scenarios.
	- Added static variables for cryptocurrency tokens and liquidity pools to streamline testing.

- **Bug Fixes**
	- Streamlined import statements by removing unused aliases.
	- Removed redundant error handling in trade methods for cleaner logic.

- **Documentation**
	- Added a new testing module to facilitate better testing practices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->