### PR TITLE
chore: update dependencies and refactor error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,15 +6,15 @@ edition = "2021"
 [dependencies]
 alloy-primitives = "0.8"
 alloy-sol-types = "0.8"
-derive_more = "1.0.0"
+#derive_more = "1.0.0"
 rustc-hash = "2.0.0"
-thiserror = { version = "1.0", optional = true }
-uniswap-sdk-core = "3.0.0"
-uniswap-v3-sdk = "2.4.0"
+thiserror = { version = "2", default-features = false }
+uniswap-sdk-core = "3.1.0"
+uniswap-v3-sdk = "2.5.0"
 
 [dev-dependencies]
 once_cell = "1.20.2"
 
 [features]
 default = []
-std = ["thiserror", "uniswap-sdk-core/std", "uniswap-v3-sdk/std"]
+std = ["thiserror/std", "uniswap-sdk-core/std", "uniswap-v3-sdk/std"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,39 +1,39 @@
+#![allow(clippy::missing_inline_in_public_items)]
+
 #[cfg(doc)]
 use crate::prelude::*;
 
 use alloy_sol_types::Error as SolError;
-use derive_more::From;
 use uniswap_sdk_core::error::Error as CoreError;
 use uniswap_v3_sdk::error::Error as V3Error;
 
-#[derive(Debug, From)]
-#[cfg_attr(feature = "std", derive(thiserror::Error))]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
     /// Thrown when an error occurs in the core library.
-    #[cfg_attr(feature = "std", error("{0}"))]
-    Core(#[cfg_attr(not(feature = "std"), from)] CoreError),
+    #[error("{0}")]
+    Core(#[from] CoreError),
 
     /// Thrown when an error occurs in the v3 library.
-    #[cfg_attr(feature = "std", error("{0}"))]
-    V3(#[cfg_attr(not(feature = "std"), from)] V3Error),
+    #[error("{0}")]
+    V3(#[from] V3Error),
 
     /// Thrown when an error occurs in the sol types library.
-    #[cfg_attr(feature = "std", error("{0}"))]
-    Sol(#[cfg_attr(not(feature = "std"), from)] SolError),
+    #[error("{0}")]
+    Sol(#[from] SolError),
 
     /// Thrown when the action is not supported.
-    #[cfg_attr(feature = "std", error("Unsupported action {0}"))]
+    #[error("Unsupported action {0}")]
     InvalidAction(u8),
 
     /// Thrown when the currency passed to [`get_path_currency`] is not one of the pool's
     /// currencies.
-    #[cfg_attr(feature = "std", error("Invalid currency"))]
+    #[error("Invalid currency")]
     InvalidCurrency,
 
     /// Thrown when trying to simulate a swap with an unsupported hook.
-    #[cfg_attr(feature = "std", error("Unsupported hook"))]
+    #[error("Unsupported hook")]
     UnsupportedHook,
 
-    #[cfg_attr(feature = "std", error("Insufficient liquidity"))]
+    #[error("Insufficient liquidity")]
     InsufficientLiquidity,
 }


### PR DESCRIPTION
Commented out `derive_more` dependency and updated versions for `thiserror`, `uniswap-sdk-core`, and `uniswap-v3-sdk` in `Cargo.toml`. Refactored error handling in `src/error.rs` to remove `derive_more` and improve error attribute usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling with clearer and more consistent error messages.

- **Bug Fixes**
	- Updated dependencies for improved stability and functionality.

- **Documentation**
	- Updated feature configurations for better clarity in usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->