### PR TITLE
chore: update dependencies in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,10 @@ exclude = [".github", ".gitignore", "rustfmt.toml"]
 alloy-primitives = "0.8"
 alloy-sol-types = "0.8"
 derive_more = "1.0.0"
-rustc-hash = "2.0.0"
+rustc-hash = "2.1.0"
 thiserror = { version = "2", default-features = false }
 uniswap-sdk-core = "3.2.0"
-uniswap-v3-sdk = "2.6.0"
+uniswap-v3-sdk = "2.9.0"
 
 [dev-dependencies]
 once_cell = "1.20.2"


### PR DESCRIPTION
Upgraded `rustc-hash` to 2.1.0 and `uniswap-v3-sdk` to 2.9.0. These updates ensure compatibility with the latest library versions and potentially include performance improvements or bug fixes.