### PR TITLE
fix: remove `SETTLE_TAKE_PAIR` and update action discriminants

### DIFF
--- a/src/utils/v4_base_actions_parser.rs
+++ b/src/utils/v4_base_actions_parser.rs
@@ -55,10 +55,6 @@ mod tests {
             Actions::CLOSE_CURRENCY(CloseCurrencyParams {
                 currency: ADDRESS_ONE,
             }),
-            Actions::SETTLE_TAKE_PAIR(SettleTakePairParams {
-                settleCurrency: ADDRESS_ONE,
-                takeCurrency: ADDRESS_TWO,
-            }),
             Actions::TAKE_PAIR(TakePairParams {
                 currency0: ADDRESS_ONE,
                 currency1: ADDRESS_TWO,

--- a/src/utils/v4_planner.rs
+++ b/src/utils/v4_planner.rs
@@ -15,26 +15,24 @@ pub enum Actions {
     MINT_POSITION(MintPositionParams) = 0x02,
     BURN_POSITION(BurnPositionParams) = 0x03,
     // Swapping
-    SWAP_EXACT_IN_SINGLE(SwapExactInSingleParams) = 0x04,
-    SWAP_EXACT_IN(SwapExactInParams) = 0x05,
-    SWAP_EXACT_OUT_SINGLE(SwapExactOutSingleParams) = 0x06,
-    SWAP_EXACT_OUT(SwapExactOutParams) = 0x07,
+    SWAP_EXACT_IN_SINGLE(SwapExactInSingleParams) = 0x06,
+    SWAP_EXACT_IN(SwapExactInParams) = 0x07,
+    SWAP_EXACT_OUT_SINGLE(SwapExactOutSingleParams) = 0x08,
+    SWAP_EXACT_OUT(SwapExactOutParams) = 0x09,
 
     // Closing deltas on the pool manager
     // Settling
-    SETTLE(SettleParams) = 0x09,
-    SETTLE_ALL(SettleAllParams) = 0x10,
-    SETTLE_PAIR(SettlePairParams) = 0x11,
+    SETTLE(SettleParams) = 0x0b,
+    SETTLE_ALL(SettleAllParams) = 0x0c,
+    SETTLE_PAIR(SettlePairParams) = 0x0d,
     // Taking
-    TAKE(TakeParams) = 0x12,
-    TAKE_ALL(TakeAllParams) = 0x13,
-    TAKE_PORTION(TakePortionParams) = 0x14,
-    TAKE_PAIR(TakePairParams) = 0x15,
+    TAKE(TakeParams) = 0x0e,
+    TAKE_ALL(TakeAllParams) = 0x0f,
+    TAKE_PORTION(TakePortionParams) = 0x10,
+    TAKE_PAIR(TakePairParams) = 0x11,
 
-    SETTLE_TAKE_PAIR(SettleTakePairParams) = 0x16,
-
-    CLOSE_CURRENCY(CloseCurrencyParams) = 0x17,
-    SWEEP(SweepParams) = 0x19,
+    CLOSE_CURRENCY(CloseCurrencyParams) = 0x12,
+    SWEEP(SweepParams) = 0x14,
 }
 
 /// https://doc.rust-lang.org/error_codes/E0732.html
@@ -67,7 +65,6 @@ impl Actions {
             Self::TAKE_ALL(params) => params.abi_encode(),
             Self::TAKE_PORTION(params) => params.abi_encode(),
             Self::TAKE_PAIR(params) => params.abi_encode(),
-            Self::SETTLE_TAKE_PAIR(params) => params.abi_encode(),
             Self::CLOSE_CURRENCY(params) => params.abi_encode(),
             Self::SWEEP(params) => params.abi_encode(),
         }
@@ -82,20 +79,19 @@ impl Actions {
             0x01 => Self::DECREASE_LIQUIDITY(DecreaseLiquidityParams::abi_decode(data, true)?),
             0x02 => Self::MINT_POSITION(MintPositionParams::abi_decode(data, true)?),
             0x03 => Self::BURN_POSITION(BurnPositionParams::abi_decode(data, true)?),
-            0x04 => Self::SWAP_EXACT_IN_SINGLE(SwapExactInSingleParams::abi_decode(data, true)?),
-            0x05 => Self::SWAP_EXACT_IN(SwapExactInParams::abi_decode(data, true)?),
-            0x06 => Self::SWAP_EXACT_OUT_SINGLE(SwapExactOutSingleParams::abi_decode(data, true)?),
-            0x07 => Self::SWAP_EXACT_OUT(SwapExactOutParams::abi_decode(data, true)?),
-            0x09 => Self::SETTLE(SettleParams::abi_decode(data, true)?),
-            0x10 => Self::SETTLE_ALL(SettleAllParams::abi_decode(data, true)?),
-            0x11 => Self::SETTLE_PAIR(SettlePairParams::abi_decode(data, true)?),
-            0x12 => Self::TAKE(TakeParams::abi_decode(data, true)?),
-            0x13 => Self::TAKE_ALL(TakeAllParams::abi_decode(data, true)?),
-            0x14 => Self::TAKE_PORTION(TakePortionParams::abi_decode(data, true)?),
-            0x15 => Self::TAKE_PAIR(TakePairParams::abi_decode(data, true)?),
-            0x16 => Self::SETTLE_TAKE_PAIR(SettleTakePairParams::abi_decode(data, true)?),
-            0x17 => Self::CLOSE_CURRENCY(CloseCurrencyParams::abi_decode(data, true)?),
-            0x19 => Self::SWEEP(SweepParams::abi_decode(data, true)?),
+            0x06 => Self::SWAP_EXACT_IN_SINGLE(SwapExactInSingleParams::abi_decode(data, true)?),
+            0x07 => Self::SWAP_EXACT_IN(SwapExactInParams::abi_decode(data, true)?),
+            0x08 => Self::SWAP_EXACT_OUT_SINGLE(SwapExactOutSingleParams::abi_decode(data, true)?),
+            0x09 => Self::SWAP_EXACT_OUT(SwapExactOutParams::abi_decode(data, true)?),
+            0x0b => Self::SETTLE(SettleParams::abi_decode(data, true)?),
+            0x0c => Self::SETTLE_ALL(SettleAllParams::abi_decode(data, true)?),
+            0x0d => Self::SETTLE_PAIR(SettlePairParams::abi_decode(data, true)?),
+            0x0e => Self::TAKE(TakeParams::abi_decode(data, true)?),
+            0x0f => Self::TAKE_ALL(TakeAllParams::abi_decode(data, true)?),
+            0x10 => Self::TAKE_PORTION(TakePortionParams::abi_decode(data, true)?),
+            0x11 => Self::TAKE_PAIR(TakePairParams::abi_decode(data, true)?),
+            0x12 => Self::CLOSE_CURRENCY(CloseCurrencyParams::abi_decode(data, true)?),
+            0x14 => Self::SWEEP(SweepParams::abi_decode(data, true)?),
             _ => return Err(Error::InvalidAction(command)),
         })
     }
@@ -295,42 +291,38 @@ mod tests {
         );
         assert_eq!(
             discriminant(&Actions::SWAP_EXACT_IN_SINGLE(Default::default())),
-            0x04
-        );
-        assert_eq!(
-            discriminant(&Actions::SWAP_EXACT_IN(Default::default())),
-            0x05
-        );
-        assert_eq!(
-            discriminant(&Actions::SWAP_EXACT_OUT_SINGLE(Default::default())),
             0x06
         );
         assert_eq!(
-            discriminant(&Actions::SWAP_EXACT_OUT(Default::default())),
+            discriminant(&Actions::SWAP_EXACT_IN(Default::default())),
             0x07
         );
-        assert_eq!(discriminant(&Actions::SETTLE(Default::default())), 0x09);
-        assert_eq!(discriminant(&Actions::SETTLE_ALL(Default::default())), 0x10);
+        assert_eq!(
+            discriminant(&Actions::SWAP_EXACT_OUT_SINGLE(Default::default())),
+            0x08
+        );
+        assert_eq!(
+            discriminant(&Actions::SWAP_EXACT_OUT(Default::default())),
+            0x09
+        );
+        assert_eq!(discriminant(&Actions::SETTLE(Default::default())), 0x0b);
+        assert_eq!(discriminant(&Actions::SETTLE_ALL(Default::default())), 0x0c);
         assert_eq!(
             discriminant(&Actions::SETTLE_PAIR(Default::default())),
-            0x11
+            0x0d
         );
-        assert_eq!(discriminant(&Actions::TAKE(Default::default())), 0x12);
-        assert_eq!(discriminant(&Actions::TAKE_ALL(Default::default())), 0x13);
+        assert_eq!(discriminant(&Actions::TAKE(Default::default())), 0x0e);
+        assert_eq!(discriminant(&Actions::TAKE_ALL(Default::default())), 0x0f);
         assert_eq!(
             discriminant(&Actions::TAKE_PORTION(Default::default())),
-            0x14
+            0x10
         );
-        assert_eq!(discriminant(&Actions::TAKE_PAIR(Default::default())), 0x15);
-        assert_eq!(
-            discriminant(&Actions::SETTLE_TAKE_PAIR(Default::default())),
-            0x16
-        );
+        assert_eq!(discriminant(&Actions::TAKE_PAIR(Default::default())), 0x11);
         assert_eq!(
             discriminant(&Actions::CLOSE_CURRENCY(Default::default())),
-            0x17
+            0x12
         );
-        assert_eq!(discriminant(&Actions::SWEEP(Default::default())), 0x19);
+        assert_eq!(discriminant(&Actions::SWEEP(Default::default())), 0x14);
     }
 
     #[test]
@@ -344,7 +336,7 @@ mod tests {
             sqrtPriceLimitX96: U160::ZERO,
             hookData: Bytes::default(),
         }));
-        assert_eq!(planner.actions, vec![0x04]);
+        assert_eq!(planner.actions, vec![0x06]);
         assert_eq!(
             planner.params[0],
             hex!("0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc20000000000000000000000000000000000000000000000000000000000000bb8000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000de0b6b3a764000000000000000000000000000000000000000000000000000006f05b59d3b20000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001400000000000000000000000000000000000000000000000000000000000000000").to_vec()
@@ -382,7 +374,7 @@ mod tests {
             let mut trade_planner = V4Planner::default();
             trade_planner.add_trade(&trade, None).unwrap();
 
-            assert_eq!(planner.actions, vec![0x05]);
+            assert_eq!(planner.actions, vec![0x07]);
             assert_eq!(
                 planner.params[0],
                 hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000006b175474e89094c44da98b954eedeac495271d0f00000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000de0b6b3a76400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000100000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb480000000000000000000000000000000000000000000000000000000000000bb8000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc20000000000000000000000000000000000000000000000000000000000000bb8000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000").to_vec()
@@ -409,7 +401,7 @@ mod tests {
             let mut planner = V4Planner::default();
             planner.add_trade(&trade, Some(slippage_tolerance)).unwrap();
 
-            assert_eq!(planner.actions, vec![0x07]);
+            assert_eq!(planner.actions, vec![0x09]);
             assert_eq!(
                 planner.params[0],
                 hex!("0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc200000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000de0b6b3a76400000000000000000000000000000000000000000000000000000ea8d524a2a4ae240000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000001000000000000000000000000006b175474e89094c44da98b954eedeac495271d0f0000000000000000000000000000000000000000000000000000000000000bb8000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb480000000000000000000000000000000000000000000000000000000000000bb8000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000").to_vec()
@@ -434,7 +426,7 @@ mod tests {
             let mut planner = V4Planner::default();
             planner.add_trade(&trade, Some(slippage_tolerance)).unwrap();
 
-            assert_eq!(planner.actions, vec![0x07]);
+            assert_eq!(planner.actions, vec![0x09]);
             assert_eq!(
                 planner.params[0],
                 hex!("0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc200000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000de0b6b3a76400000000000000000000000000000000000000000000000000000ea8d524a2a4ae240000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000001000000000000000000000000006b175474e89094c44da98b954eedeac495271d0f0000000000000000000000000000000000000000000000000000000000000bb8000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb480000000000000000000000000000000000000000000000000000000000000bb8000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000").to_vec()
@@ -459,7 +451,7 @@ mod tests {
             let mut planner = V4Planner::default();
             planner.add_trade(&trade, Some(slippage_tolerance)).unwrap();
 
-            assert_eq!(planner.actions, vec![0x05]);
+            assert_eq!(planner.actions, vec![0x07]);
             assert_eq!(
                 planner.params[0],
                 hex!("0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc200000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000de0b6b3a76400000000000000000000000000000000000000000000000000000d23441c93fad7ca000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000100000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb480000000000000000000000000000000000000000000000000000000000000bb8000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000000000000000000000000000006b175474e89094c44da98b954eedeac495271d0f0000000000000000000000000000000000000000000000000000000000000bb8000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000").to_vec()
@@ -517,7 +509,7 @@ mod tests {
         fn completes_v4_settle_without_specified_amount() {
             let mut planner = V4Planner::default();
             planner.add_settle(&DAI.clone(), true, None);
-            assert_eq!(planner.actions, vec![0x09]);
+            assert_eq!(planner.actions, vec![0x0b]);
             assert_eq!(
                 planner.params[0],
                 hex!("0000000000000000000000006b175474e89094c44da98b954eedeac495271d0f00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001").to_vec()
@@ -528,7 +520,7 @@ mod tests {
         fn completes_v4_settle_with_specified_amount() {
             let mut planner = V4Planner::default();
             planner.add_settle(&DAI.clone(), true, Some(uint!(8_U256)));
-            assert_eq!(planner.actions, vec![0x09]);
+            assert_eq!(planner.actions, vec![0x0b]);
             assert_eq!(
                 planner.params[0],
                 hex!("0000000000000000000000006b175474e89094c44da98b954eedeac495271d0f00000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000001").to_vec()
@@ -539,7 +531,7 @@ mod tests {
         fn completes_v4_settle_with_payer_is_user_as_false() {
             let mut planner = V4Planner::default();
             planner.add_settle(&DAI.clone(), false, Some(uint!(8_U256)));
-            assert_eq!(planner.actions, vec![0x09]);
+            assert_eq!(planner.actions, vec![0x0b]);
             assert_eq!(
                 planner.params[0],
                 hex!("0000000000000000000000006b175474e89094c44da98b954eedeac495271d0f00000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000").to_vec()
@@ -559,7 +551,7 @@ mod tests {
                 address!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
                 None,
             );
-            assert_eq!(planner.actions, vec![0x12]);
+            assert_eq!(planner.actions, vec![0x0e]);
             assert_eq!(
                 planner.params[0],
                 hex!("0000000000000000000000006b175474e89094c44da98b954eedeac495271d0f000000000000000000000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0000000000000000000000000000000000000000000000000000000000000000").to_vec()
@@ -574,7 +566,7 @@ mod tests {
                 address!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
                 Some(uint!(8_U256)),
             );
-            assert_eq!(planner.actions, vec![0x12]);
+            assert_eq!(planner.actions, vec![0x0e]);
             assert_eq!(
                 planner.params[0],
                 hex!("0000000000000000000000006b175474e89094c44da98b954eedeac495271d0f000000000000000000000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0000000000000000000000000000000000000000000000000000000000000008").to_vec()


### PR DESCRIPTION
Removed the `SETTLE_TAKE_PAIR` action as it is no longer required and adjusted the discriminant values for existing actions accordingly. Updated the tests and parsers to reflect these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Simplified test cases by removing the `SETTLE_TAKE_PAIR` action, focusing on remaining actions in the `parse_calldata` function.

- **New Features**
	- Updated action discriminant values in the `Actions` enum for various liquidity and trading operations, ensuring consistent behavior across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->