### PR TITLE
chore: refactor arithmetic and update dependencies to v0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-v4-sdk"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["Shuhui Luo <twitter.com/aureliano_law>"]
 description = "Uniswap V4 SDK for Rust"
@@ -17,11 +17,12 @@ alloy-sol-types = { version = "0.8", default-features = false }
 derive_more = { version = "2", default-features = false, features = ["deref", "deref_mut"] }
 num-traits = { version = "0.2", default-features = false, features = ["libm"] }
 thiserror = { version = "2", default-features = false }
-uniswap-sdk-core = "3.5.0"
-uniswap-v3-sdk = "3.6.0"
+uniswap-sdk-core = "4.0.0"
+uniswap-v3-sdk = "4.0.0"
 
 [dev-dependencies]
-alloy = { version = "0.11", default-features = false, features = ["signer-local"] }
+alloy = { version = "0.12", default-features = false, features = ["signer-local"] }
+num-integer = { version = "0.1", default-features = false }
 once_cell = "1.20"
 
 [features]

--- a/src/entities/pool.rs
+++ b/src/entities/pool.rs
@@ -215,12 +215,12 @@ impl<TP: TickDataProvider> Pool<TP> {
     /// over currency0
     #[inline]
     pub fn currency0_price(&self) -> Price<Currency, Currency> {
-        let sqrt_price_x96 = self.sqrt_price_x96.to_big_uint();
+        let sqrt_price_x96 = self.sqrt_price_x96.to_big_int();
         Price::new(
             self.currency0.clone(),
             self.currency1.clone(),
             Q192.to_big_int(),
-            &sqrt_price_x96 * &sqrt_price_x96,
+            sqrt_price_x96 * sqrt_price_x96,
         )
     }
 
@@ -233,11 +233,11 @@ impl<TP: TickDataProvider> Pool<TP> {
     /// over currency1
     #[inline]
     pub fn currency1_price(&self) -> Price<Currency, Currency> {
-        let sqrt_price_x96 = self.sqrt_price_x96.to_big_uint();
+        let sqrt_price_x96 = self.sqrt_price_x96.to_big_int();
         Price::new(
             self.currency1.clone(),
             self.currency0.clone(),
-            &sqrt_price_x96 * &sqrt_price_x96,
+            sqrt_price_x96 * sqrt_price_x96,
             Q192.to_big_int(),
         )
     }

--- a/src/entities/trade.rs
+++ b/src/entities/trade.rs
@@ -555,6 +555,7 @@ where
     /// * `amount`: The amount specified, either input or output, depending on `trade_type`
     /// * `trade_type`: Whether the trade is an exact input or exact output swap
     #[inline]
+    #[allow(clippy::needless_pass_by_value)]
     pub fn from_route(
         route: Route<TInput, TOutput, TP>,
         amount: CurrencyAmount<impl BaseCurrency>,
@@ -838,6 +839,7 @@ where
 mod tests {
     use super::*;
     use crate::tests::*;
+    use num_integer::Roots;
     use num_traits::ToPrimitive;
     use once_cell::sync::Lazy;
 

--- a/src/utils/path_currency.rs
+++ b/src/utils/path_currency.rs
@@ -9,8 +9,8 @@ pub fn amount_with_path_currency<TP: TickDataProvider>(
 ) -> Result<CurrencyAmount<Currency>, Error> {
     Ok(CurrencyAmount::from_fractional_amount(
         get_path_currency(&amount.currency, pool)?,
-        amount.numerator.clone(),
-        amount.denominator.clone(),
+        amount.numerator,
+        amount.denominator,
     )?)
 }
 

--- a/src/utils/price_tick_conversions.rs
+++ b/src/utils/price_tick_conversions.rs
@@ -22,8 +22,8 @@ pub fn tick_to_price(
     tick: I24,
 ) -> Result<Price<Currency, Currency>, Error> {
     let sqrt_ratio_x96 = get_sqrt_ratio_at_tick(tick)?;
-    let ratio_x192 = sqrt_ratio_x96.to_big_uint().pow(2);
-    let q192 = Q192.to_big_uint();
+    let ratio_x192 = sqrt_ratio_x96.to_big_int().pow(2);
+    let q192 = Q192.to_big_int();
     Ok(if sorts_before(&base_currency, &quote_currency)? {
         Price::new(base_currency, quote_currency, q192, ratio_x192)
     } else {
@@ -42,9 +42,9 @@ pub fn price_to_closest_tick(price: &Price<Currency, Currency>) -> Result<I24, E
     const ONE: I24 = I24::from_limbs([1]);
     let sorted = sorts_before(&price.base_currency, &price.quote_currency)?;
     let sqrt_ratio_x96: U160 = if sorted {
-        encode_sqrt_ratio_x96(price.numerator.clone(), price.denominator.clone())
+        encode_sqrt_ratio_x96(price.numerator, price.denominator)
     } else {
-        encode_sqrt_ratio_x96(price.denominator.clone(), price.numerator.clone())
+        encode_sqrt_ratio_x96(price.denominator, price.numerator)
     };
     let tick = sqrt_ratio_x96.get_tick_at_sqrt_ratio()?;
     let next_tick_price = tick_to_price(


### PR DESCRIPTION
Changed arithmetic operations to use `to_big_int` for consistency and efficiency. Removed unnecessary `.clone()` calls for cleaner code. Bumped package version to 0.4.0 and updated dependencies for compatibility and feature enhancements.

Closes #27.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Upgraded the package to version 0.4.0 and refreshed several dependency libraries for improved overall stability.
  
- **Refactor**
  - Optimized numerical conversions and arithmetic operations in financial and trade computations, reducing redundant processing and enhancing performance.
  
- **Tests**
  - Strengthened testing support for mathematical operations to ensure precise and reliable outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->