### PR TITLE
refactor!: update to alloy 1.0 and refactor async calls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-v4-sdk"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 rust-version = "1.83"
 authors = ["Shuhui Luo <twitter.com/aureliano_law>"]
@@ -16,21 +16,21 @@ exclude = [".github", ".gitignore", "rustfmt.toml"]
 all-features = true
 
 [dependencies]
-alloy = { version = "0.13", optional = true, default-features = false, features = ["contract"] }
-alloy-primitives = { version = "0.8", default-features = false }
-alloy-sol-types = { version = "0.8", default-features = false }
+alloy = { version = "1.0.1", optional = true, default-features = false, features = ["contract"] }
+alloy-primitives = { version = "1.0", default-features = false }
+alloy-sol-types = { version = "1.0", default-features = false }
 derive_more = { version = "2", default-features = false, features = ["deref", "deref_mut"] }
 num-traits = { version = "0.2", default-features = false, features = ["libm"] }
 thiserror = { version = "2", default-features = false }
-uniswap-sdk-core = "4.1.0"
-uniswap-v3-sdk = "4.3.0"
+uniswap-sdk-core = "5.1.0"
+uniswap-v3-sdk = "5.0.0"
 
 [dev-dependencies]
-alloy = { version = "0.13", default-features = false, features = ["reqwest", "signer-local"] }
+alloy = { version = "1.0.1", default-features = false, features = ["reqwest", "signer-local"] }
 dotenv = "0.15.0"
 num-integer = { version = "0.1", default-features = false }
 once_cell = "1.21"
-tokio = { version = "1.44", features = ["full"] }
+tokio = { version = "1.45", features = ["full"] }
 
 [features]
 default = []

--- a/src/error.rs
+++ b/src/error.rs
@@ -47,6 +47,6 @@ pub enum Error {
 pub fn map_contract_error(e: Error) -> V3Error {
     match e {
         Error::ContractError(contract_error) => V3Error::ContractError(contract_error),
-        _ => panic!("Unexpected error: {:?}", e),
+        _ => panic!("Unexpected error: {e:?}"),
     }
 }

--- a/src/position_manager.rs
+++ b/src/position_manager.rs
@@ -1,6 +1,6 @@
 use crate::prelude::{Error, *};
 use alloc::vec::Vec;
-use alloy_primitives::{address, Address, Bytes, PrimitiveSignature, U160, U256};
+use alloy_primitives::{address, Address, Bytes, Signature, U160, U256};
 use alloy_sol_types::{eip712_domain, SolCall};
 use derive_more::{Deref, DerefMut};
 use num_traits::ToPrimitive;
@@ -116,7 +116,7 @@ pub struct NFTPermitOptions {
     #[deref]
     #[deref_mut]
     pub values: NFTPermitValues,
-    pub signature: PrimitiveSignature,
+    pub signature: Signature,
 }
 
 /// Public methods to encode method parameters for different actions on the PositionManager contract
@@ -454,7 +454,7 @@ pub fn encode_erc721_permit(
 ///
 /// ```
 /// use alloy::signers::{local::PrivateKeySigner, SignerSync};
-/// use alloy_primitives::{address, b256, uint, PrimitiveSignature, B256};
+/// use alloy_primitives::{address, b256, uint, Signature, B256};
 /// use alloy_sol_types::SolStruct;
 /// use uniswap_v4_sdk::prelude::*;
 ///
@@ -478,7 +478,7 @@ pub fn encode_erc721_permit(
 /// let hash: B256 = data.eip712_signing_hash();
 ///
 /// let signer = PrivateKeySigner::random();
-/// let signature: PrimitiveSignature = signer.sign_hash_sync(&hash).unwrap();
+/// let signature: Signature = signer.sign_hash_sync(&hash).unwrap();
 /// assert_eq!(
 ///     signature.recover_address_from_prehash(&hash).unwrap(),
 ///     signer.address()

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -150,7 +150,7 @@ mod extensions {
     pub(crate) static PROVIDER: Lazy<RootProvider> = Lazy::new(|| {
         ProviderBuilder::new()
             .disable_recommended_fillers()
-            .on_http(RPC_URL.clone())
+            .connect_http(RPC_URL.clone())
     });
 
     pub(crate) const BLOCK_ID: Option<BlockId> =
@@ -167,7 +167,7 @@ mod extensions {
         .unwrap()
     });
 
-    pub(crate) static STATE_VIEW: Lazy<IStateView::IStateViewInstance<(), RootProvider>> =
+    pub(crate) static STATE_VIEW: Lazy<IStateView::IStateViewInstance<RootProvider>> =
         Lazy::new(|| {
             IStateView::new(
                 CHAIN_TO_ADDRESSES_MAP

--- a/src/utils/v4_base_actions_parser.rs
+++ b/src/utils/v4_base_actions_parser.rs
@@ -12,7 +12,7 @@ pub struct V4RouterCall {
 #[inline]
 pub fn parse_calldata(calldata: &Bytes) -> Result<V4RouterCall, Error> {
     let ActionsParams { actions, params } =
-        ActionsParams::abi_decode(calldata.iter().as_slice(), true)?;
+        ActionsParams::abi_decode_validate(calldata.iter().as_slice())?;
     Ok(V4RouterCall {
         actions: zip(actions, params)
             .map(|(command, data)| Actions::abi_decode(command, &data))

--- a/src/utils/v4_planner.rs
+++ b/src/utils/v4_planner.rs
@@ -76,23 +76,25 @@ impl Actions {
     pub fn abi_decode(command: u8, data: &Bytes) -> Result<Self, Error> {
         let data = data.iter().as_slice();
         Ok(match command {
-            0x00 => Self::INCREASE_LIQUIDITY(IncreaseLiquidityParams::abi_decode(data, true)?),
-            0x01 => Self::DECREASE_LIQUIDITY(DecreaseLiquidityParams::abi_decode(data, true)?),
-            0x02 => Self::MINT_POSITION(MintPositionParams::abi_decode(data, true)?),
-            0x03 => Self::BURN_POSITION(BurnPositionParams::abi_decode(data, true)?),
-            0x06 => Self::SWAP_EXACT_IN_SINGLE(SwapExactInSingleParams::abi_decode(data, true)?),
-            0x07 => Self::SWAP_EXACT_IN(SwapExactInParams::abi_decode(data, true)?),
-            0x08 => Self::SWAP_EXACT_OUT_SINGLE(SwapExactOutSingleParams::abi_decode(data, true)?),
-            0x09 => Self::SWAP_EXACT_OUT(SwapExactOutParams::abi_decode(data, true)?),
-            0x0b => Self::SETTLE(SettleParams::abi_decode(data, true)?),
-            0x0c => Self::SETTLE_ALL(SettleAllParams::abi_decode(data, true)?),
-            0x0d => Self::SETTLE_PAIR(SettlePairParams::abi_decode(data, true)?),
-            0x0e => Self::TAKE(TakeParams::abi_decode(data, true)?),
-            0x0f => Self::TAKE_ALL(TakeAllParams::abi_decode(data, true)?),
-            0x10 => Self::TAKE_PORTION(TakePortionParams::abi_decode(data, true)?),
-            0x11 => Self::TAKE_PAIR(TakePairParams::abi_decode(data, true)?),
-            0x12 => Self::CLOSE_CURRENCY(CloseCurrencyParams::abi_decode(data, true)?),
-            0x14 => Self::SWEEP(SweepParams::abi_decode(data, true)?),
+            0x00 => Self::INCREASE_LIQUIDITY(IncreaseLiquidityParams::abi_decode_validate(data)?),
+            0x01 => Self::DECREASE_LIQUIDITY(DecreaseLiquidityParams::abi_decode_validate(data)?),
+            0x02 => Self::MINT_POSITION(MintPositionParams::abi_decode_validate(data)?),
+            0x03 => Self::BURN_POSITION(BurnPositionParams::abi_decode_validate(data)?),
+            0x06 => Self::SWAP_EXACT_IN_SINGLE(SwapExactInSingleParams::abi_decode_validate(data)?),
+            0x07 => Self::SWAP_EXACT_IN(SwapExactInParams::abi_decode_validate(data)?),
+            0x08 => {
+                Self::SWAP_EXACT_OUT_SINGLE(SwapExactOutSingleParams::abi_decode_validate(data)?)
+            }
+            0x09 => Self::SWAP_EXACT_OUT(SwapExactOutParams::abi_decode_validate(data)?),
+            0x0b => Self::SETTLE(SettleParams::abi_decode_validate(data)?),
+            0x0c => Self::SETTLE_ALL(SettleAllParams::abi_decode_validate(data)?),
+            0x0d => Self::SETTLE_PAIR(SettlePairParams::abi_decode_validate(data)?),
+            0x0e => Self::TAKE(TakeParams::abi_decode_validate(data)?),
+            0x0f => Self::TAKE_ALL(TakeAllParams::abi_decode_validate(data)?),
+            0x10 => Self::TAKE_PORTION(TakePortionParams::abi_decode_validate(data)?),
+            0x11 => Self::TAKE_PAIR(TakePairParams::abi_decode_validate(data)?),
+            0x12 => Self::CLOSE_CURRENCY(CloseCurrencyParams::abi_decode_validate(data)?),
+            0x14 => Self::SWEEP(SweepParams::abi_decode_validate(data)?),
             _ => return Err(Error::InvalidAction(command)),
         })
     }


### PR DESCRIPTION
- Upgrade `Alloy` dependencies to version `1.0`.
- Replace `PrimitiveSignature` with `Signature` for compatibility.
- Simplify async calls by removing redundant `.value` and `.values`.
- Use `abi_decode_validate` for improved calldata validation.
- Adjust test loops and event filtering for efficiency.
- Bump SDK version to `0.7.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved decoding and validation for calldata and planner actions, enhancing reliability when parsing and processing data.
	- Corrected field and type parameters in pool manager lens and tests to ensure consistent and accurate type usage.
	- Updated signature type in NFT permit options for better compatibility.

- **Chores**
	- Upgraded several dependencies to newer versions for improved stability and compatibility.
	- Updated provider connection method and simplified type annotations in tests.
	- Improved formatting of error messages for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->