### PR TITLE
fix: correct input reference in `Route::mid_price`

### DIFF
--- a/src/entities/route.rs
+++ b/src/entities/route.rs
@@ -97,7 +97,7 @@ where
     /// Returns the mid price of the route
     #[inline]
     pub fn mid_price(&self) -> Result<Price<TInput, TOutput>, Error> {
-        let mut price = self.pools[0].price_of(&self.path_input)?;
+        let mut price = self.pools[0].price_of(&self.input)?;
         for pool in &self.pools[1..] {
             price = price.multiply(&pool.price_of(&price.quote_currency)?)?;
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the starting currency used in route mid-price calculations, improving price accuracy for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->