### PR TITLE
doc: integrate reusable test utilities and add Permit2 example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ alloy-primitives = { version = "1.0", default-features = false }
 alloy-sol-types = { version = "1.0", default-features = false }
 derive_more = { version = "2", default-features = false, features = ["deref", "deref_mut", "from"] }
 num-traits = { version = "0.2", default-features = false, features = ["libm"] }
+once_cell = { version = "1.21", optional = true }
+dotenv = { version = "0.15", optional = true }
 thiserror = { version = "2", default-features = false }
 uniswap-sdk-core = "5.1.0"
 uniswap-v3-sdk = "5.0.0"
@@ -45,7 +47,16 @@ extensions = [
     "alloy",
     "uniswap-v3-sdk/extensions"
 ]
+test-utils = [
+    "dotenv",
+    "once_cell",
+    "std"
+]
 
 [[example]]
 name = "mint_position_basic"
-required-features = ["extensions"]
+required-features = ["extensions", "test-utils"]
+
+[[example]]
+name = "mint_position_permit2"
+required-features = ["extensions", "test-utils"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,9 @@ extensions = [
     "uniswap-v3-sdk/extensions"
 ]
 test-utils = [
+    "alloy/provider-anvil-node",
+    "alloy/reqwest",
+    "alloy/signer-local",
     "dotenv",
     "once_cell",
     "std"

--- a/examples/README.md
+++ b/examples/README.md
@@ -31,11 +31,11 @@ cargo build --features extensions
 
 ### Advanced Examples
 
-- **[mint_position_create_pool.rs](./mint_position_create_pool.rs)** - Shows how to create a new V4 pool and mint a
-  position in the same transaction
-
 - **[mint_position_permit2.rs](./mint_position_permit2.rs)** - Demonstrates using Permit2 for gasless token approvals
   when minting positions
+
+- **[mint_position_create_pool.rs](./mint_position_create_pool.rs)** - Shows how to create a new V4 pool and mint a
+  position in the same transaction
 
 ## Running Examples
 
@@ -43,14 +43,17 @@ Each example can be run independently:
 
 ```bash
 # Run the basic minting example
-cargo run --example mint_position_basic --features extensions
+cargo run --example mint_position_basic --features extensions,test-utils
 
 # Run the create pool + mint example  
-cargo run --example mint_position_create_pool --features extensions
+cargo run --example mint_position_create_pool --features extensions,test-utils
 
 # Run the permit2 example
-cargo run --example mint_position_permit2 --features extensions
+cargo run --example mint_position_permit2 --features extensions,test-utils
 ```
+
+**Note**: Examples require both `extensions` (for V4 functionality) and `test-utils` (for test tokens and helper
+functions) features.
 
 ## Key Concepts
 
@@ -76,10 +79,17 @@ All examples use Anvil forking to create a local testnet that mirrors the mainne
 - Create test accounts with ETH balances
 - Set up token balances and approvals
 - Execute transactions in the forked environment
+
 ## Common Patterns
 
 - Use `uniswap_v4_sdk::prelude::*` for easy imports
-- Import test utilities from the main crate's test module
+- Import test utilities with `use uniswap_v4_sdk::tests::*` (requires `test-utils` feature)
 - Set up Anvil provider for local testing
 - Handle both native ETH and ERC20 tokens as currencies
 - Use appropriate slippage tolerance and deadline parameters
+
+## Features
+
+- **`extensions`**: Core V4 functionality including `PoolManagerLens` and RPC capabilities
+- **`test-utils`**: Test tokens, helper functions, and utilities for examples and testing (includes `once_cell`,
+  `dotenv`, `std`)

--- a/src/abi.rs
+++ b/src/abi.rs
@@ -214,7 +214,7 @@ alloy::sol! {
     }
 }
 
-#[cfg(all(test, feature = "extensions"))]
+#[cfg(feature = "extensions")]
 alloy::sol! {
     type PoolId is bytes32;
 

--- a/src/entities/position.rs
+++ b/src/entities/position.rs
@@ -408,7 +408,7 @@ impl<TP: TickDataProvider> Position<TP> {
         slippage_tolerance: &Percent,
         spender: Address,
         nonce: U256,
-        deadline: U256,
+        deadline: U48,
     ) -> Result<AllowanceTransferPermitBatch, Error> {
         let MintAmounts { amount0, amount1 } =
             self.mint_amounts_with_slippage(slippage_tolerance)?;
@@ -417,18 +417,18 @@ impl<TP: TickDataProvider> Position<TP> {
                 IAllowanceTransfer::PermitDetails {
                     token: self.pool.currency0.wrapped().address(),
                     amount: U160::from(amount0),
-                    expiration: U48::from(deadline),
+                    expiration: deadline,
                     nonce: U48::from(nonce),
                 },
                 IAllowanceTransfer::PermitDetails {
                     token: self.pool.currency1.wrapped().address(),
                     amount: U160::from(amount1),
-                    expiration: U48::from(deadline),
+                    expiration: deadline,
                     nonce: U48::from(nonce),
                 },
             ],
             spender,
-            sigDeadline: deadline,
+            sigDeadline: U256::from(deadline),
         })
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,8 +37,8 @@ pub use uniswap_v3_sdk::multicall;
 #[cfg(feature = "extensions")]
 pub mod extensions;
 
-#[cfg(test)]
-mod tests;
+#[cfg(any(test, feature = "test-utils"))]
+pub mod tests;
 
 pub mod prelude {
     pub use crate::{abi::*, entities::*, error::*, multicall::*, position_manager::*, utils::*};

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -138,32 +138,18 @@ macro_rules! trade_from_route {
     };
 }
 
-#[cfg(all(feature = "extensions", feature = "test-utils"))]
-pub use extensions::*;
+#[cfg(feature = "extensions")]
+pub(crate) use extensions::*;
 
-#[cfg(all(feature = "extensions", feature = "test-utils"))]
+#[cfg(feature = "extensions")]
 mod extensions {
     use super::*;
-    use crate::{
-        position_manager::{AddLiquidityOptions, AddLiquiditySpecificOptions, MintSpecificOptions},
-        prelude::*,
-    };
-    use alloc::boxed::Box;
+    use crate::abi::IStateView;
     use alloy::{
         eips::{BlockId, BlockNumberOrTag},
-        providers::{
-            ext::AnvilApi,
-            fillers::{
-                BlobGasFiller, ChainIdFiller, FillProvider, GasFiller, JoinFill, NonceFiller,
-            },
-            layers::AnvilProvider,
-            Identity, Provider, ProviderBuilder, RootProvider,
-        },
-        signers::{local::PrivateKeySigner, SignerSync},
+        providers::{ProviderBuilder, RootProvider},
         transports::http::reqwest::Url,
     };
-    use alloy_primitives::{aliases::U24, Bytes, Signature, B256, U256};
-    use alloy_sol_types::{eip712_domain, Eip712Domain, SolStruct};
 
     pub(crate) static RPC_URL: Lazy<Url> = Lazy::new(|| {
         dotenv::dotenv().ok();
@@ -201,6 +187,32 @@ mod extensions {
                 PROVIDER.clone(),
             )
         });
+}
+
+#[cfg(all(feature = "extensions", feature = "test-utils"))]
+pub use examples::*;
+
+#[cfg(all(feature = "extensions", feature = "test-utils"))]
+mod examples {
+    use super::*;
+    use crate::{
+        position_manager::{AddLiquidityOptions, AddLiquiditySpecificOptions, MintSpecificOptions},
+        prelude::*,
+    };
+    use alloc::boxed::Box;
+    use alloy::{
+        providers::{
+            ext::AnvilApi,
+            fillers::{
+                BlobGasFiller, ChainIdFiller, FillProvider, GasFiller, JoinFill, NonceFiller,
+            },
+            layers::AnvilProvider,
+            Identity, Provider, ProviderBuilder, RootProvider,
+        },
+        signers::{local::PrivateKeySigner, SignerSync},
+    };
+    use alloy_primitives::{aliases::U24, Bytes, Signature, B256, U256};
+    use alloy_sol_types::{eip712_domain, Eip712Domain, SolStruct};
 
     /// Set up an Anvil fork from mainnet at a specific block
     #[inline]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,13 +1,20 @@
+//! Test utilities and helper functions
+#![cfg_attr(not(test), allow(dead_code))]
+
 use crate::entities::Pool;
 pub(crate) use alloc::vec;
-use alloy_primitives::U160;
+use alloy_primitives::{address, Address, U160};
 use once_cell::sync::Lazy;
 use uniswap_sdk_core::{prelude::*, token};
 use uniswap_v3_sdk::prelude::*;
 
-pub(crate) static ETHER: Lazy<Ether> = Lazy::new(|| Ether::on_chain(1));
+pub const PERMIT2_ADDRESS: Address = address!("000000000022D473030F116dDEE9F6B43aC78BA3");
+
+pub static ETHER: Lazy<Ether> = Lazy::new(|| Ether::on_chain(1));
+
 pub(crate) static WETH: Lazy<Token> = Lazy::new(|| ETHER.wrapped().clone());
-pub(crate) static USDC: Lazy<Token> = Lazy::new(|| {
+
+pub static USDC: Lazy<Token> = Lazy::new(|| {
     token!(
         1,
         "A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
@@ -131,18 +138,32 @@ macro_rules! trade_from_route {
     };
 }
 
-#[cfg(feature = "extensions")]
-pub(crate) use extensions::*;
+#[cfg(all(feature = "extensions", feature = "test-utils"))]
+pub use extensions::*;
 
-#[cfg(feature = "extensions")]
+#[cfg(all(feature = "extensions", feature = "test-utils"))]
 mod extensions {
     use super::*;
-    use crate::abi::IStateView;
+    use crate::{
+        position_manager::{AddLiquidityOptions, AddLiquiditySpecificOptions, MintSpecificOptions},
+        prelude::*,
+    };
+    use alloc::boxed::Box;
     use alloy::{
         eips::{BlockId, BlockNumberOrTag},
-        providers::{ProviderBuilder, RootProvider},
+        providers::{
+            ext::AnvilApi,
+            fillers::{
+                BlobGasFiller, ChainIdFiller, FillProvider, GasFiller, JoinFill, NonceFiller,
+            },
+            layers::AnvilProvider,
+            Identity, Provider, ProviderBuilder, RootProvider,
+        },
+        signers::{local::PrivateKeySigner, SignerSync},
         transports::http::reqwest::Url,
     };
+    use alloy_primitives::{aliases::U24, Bytes, Signature, B256, U256};
+    use alloy_sol_types::{eip712_domain, Eip712Domain, SolStruct};
 
     pub(crate) static RPC_URL: Lazy<Url> = Lazy::new(|| {
         dotenv::dotenv().ok();
@@ -180,4 +201,125 @@ mod extensions {
                 PROVIDER.clone(),
             )
         });
+
+    /// Set up an Anvil fork from mainnet at a specific block
+    #[inline]
+    pub async fn setup_anvil_fork(
+        fork_block: u64,
+    ) -> FillProvider<
+        JoinFill<
+            Identity,
+            JoinFill<GasFiller, JoinFill<BlobGasFiller, JoinFill<NonceFiller, ChainIdFiller>>>,
+        >,
+        AnvilProvider<RootProvider>,
+    > {
+        ProviderBuilder::new().connect_anvil_with_config(|anvil| {
+            anvil.fork(RPC_URL.clone()).fork_block_number(fork_block)
+        })
+    }
+
+    /// Create a test account with ETH balance
+    #[inline]
+    pub async fn setup_test_account(provider: &impl Provider, balance: U256) -> PrivateKeySigner {
+        let signer = PrivateKeySigner::random();
+        let account = signer.address();
+        provider.anvil_set_balance(account, balance).await.unwrap();
+        signer
+    }
+
+    /// Create a pool from on-chain state
+    #[inline]
+    pub async fn create_pool(
+        provider: &impl Provider,
+        v4_pool_manager: Address,
+        currency0: Currency,
+        currency1: Currency,
+        fee: U24,
+        tick_spacing: i32,
+        hook_address: Address,
+    ) -> Result<Pool, Box<dyn core::error::Error>> {
+        let pool_id = Pool::get_pool_id(&currency0, &currency1, fee, tick_spacing, hook_address)?;
+
+        let pool_lens = PoolManagerLens::new(v4_pool_manager, provider);
+        let (actual_sqrt_price, _, _, _) = pool_lens.get_slot0(pool_id, None).await?;
+
+        Ok(Pool::new(
+            currency0,
+            currency1,
+            fee,
+            tick_spacing,
+            hook_address,
+            actual_sqrt_price,
+            0,
+        )?)
+    }
+
+    /// Setup token balance and approval for a single token
+    #[inline]
+    pub async fn setup_token_balance(
+        provider: &impl Provider,
+        token_address: Address,
+        account: Address,
+        amount: U256,
+        approve_to: Address,
+    ) -> Result<(), Box<dyn core::error::Error>> {
+        let overrides =
+            get_erc20_state_overrides(token_address, account, approve_to, amount, provider).await?;
+
+        for (token, account_override) in overrides {
+            for (slot, value) in account_override.state_diff.unwrap() {
+                provider
+                    .anvil_set_storage_at(token, U256::from_be_bytes(slot.0), value)
+                    .await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Get Permit2 EIP-712 domain for mainnet
+    #[inline]
+    #[must_use]
+    pub const fn get_permit2_domain() -> Eip712Domain {
+        eip712_domain! {
+            name: "Permit2",
+            chain_id: 1,
+            verifying_contract: PERMIT2_ADDRESS,
+        }
+    }
+
+    /// Create EIP-712 signature for Permit2 batch permit
+    #[inline]
+    pub fn create_permit2_signature(
+        permit_batch: &AllowanceTransferPermitBatch,
+        signer: &PrivateKeySigner,
+    ) -> Result<Bytes, Box<dyn core::error::Error>> {
+        let domain = get_permit2_domain();
+        let hash: B256 = permit_batch.eip712_signing_hash(&domain);
+        let signature: Signature = signer.sign_hash_sync(&hash)?;
+        Ok(signature.as_bytes().into())
+    }
+
+    /// Create AddLiquidityOptions for minting positions
+    #[inline]
+    pub fn create_add_liquidity_options(
+        recipient: Address,
+        batch_permit: Option<BatchPermitOptions>,
+    ) -> AddLiquidityOptions {
+        AddLiquidityOptions {
+            common_opts: CommonOptions {
+                slippage_tolerance: Percent::new(1, 1000),
+                deadline: U256::MAX,
+                hook_data: Default::default(),
+            },
+            use_native: Some(ETHER.clone()),
+            batch_permit,
+            specific_opts: AddLiquiditySpecificOptions::Mint(MintSpecificOptions {
+                recipient,
+                create_pool: false,
+                sqrt_price_x96: None,
+                migrate: false,
+            }),
+        }
+    }
 }


### PR DESCRIPTION
- Refactored `mint_position_basic.rs` and `mint_position_permit2.rs` to utilize shared helper methods from the new `test-utils` module.
- Added `test-utils` module, providing utilities for Anvil setup, token management, pool creation, and Permit2 operations.
- Introduced `mint_position_permit2.rs` example, demonstrating gasless approvals with Permit2.
- Updated `examples/README.md` to include `test-utils` feature usage and example details.
- Adjusted `Cargo.toml` to add `test-utils`, `dotenv`, and `once_cell` dependencies.
- Modified `Position::permit_batch_data` to ensure `U48` deadline consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new example demonstrating minting a Uniswap V4 position using Permit2 for gasless approvals.
  * Added comprehensive test utilities for blockchain state manipulation, pool creation, token balance setup, and Permit2 permit signing.
  * Added a new feature flag `test-utils` providing test tokens, helpers, and utilities for examples and testing.

* **Enhancements**
  * Refactored the basic mint position example for improved modularity, error handling, and use of reusable test utilities.
  * Updated documentation to clarify feature requirements and usage instructions for running examples.

* **API Changes**
  * Updated method signatures to use more precise types for deadlines and improved error propagation.
  * Made test utilities and constants publicly accessible when the appropriate features are enabled.

* **Other**
  * Adjusted feature flags and conditional compilation to make test utilities available outside of test builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->