### PR TITLE
feat(ext): add position key and NFT extraction utilities

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-v4-sdk"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 rust-version = "1.86"
 authors = ["Shuhui Luo <twitter.com/aureliano_law>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [".github", ".gitignore", "rustfmt.toml"]
 all-features = true
 
 [dependencies]
-alloy = { version = "1.0.1", optional = true, default-features = false, features = ["contract"] }
+alloy = { version = "1.0.23", optional = true, default-features = false, features = ["contract"] }
 alloy-primitives = { version = "1.3", default-features = false }
 alloy-sol-types = { version = "1.3", default-features = false }
 derive_more = { version = "2", default-features = false, features = ["deref", "deref_mut", "from"] }
@@ -28,7 +28,7 @@ uniswap-sdk-core = "5.2.0"
 uniswap-v3-sdk = "5.2.0"
 
 [dev-dependencies]
-alloy = { version = "1.0.1", default-features = false, features = ["provider-anvil-node", "reqwest", "signer-local"] }
+alloy = { version = "1.0.23", default-features = false, features = ["provider-anvil-node", "reqwest", "signer-local"] }
 dotenv = "0.15"
 num-integer = { version = "0.1", default-features = false }
 once_cell = "1.21"

--- a/src/abi.rs
+++ b/src/abi.rs
@@ -218,6 +218,12 @@ alloy::sol! {
 alloy::sol! {
     type PoolId is bytes32;
 
+    event ModifyLiquidity(
+        PoolId indexed id, address indexed sender, int24 tickLower, int24 tickUpper, int256 liquidityDelta, bytes32 salt
+    );
+
+    event Transfer(address indexed from, address indexed to, uint256 indexed tokenId);
+
     #[sol(rpc)]
     #[derive(Debug)]
     interface IStateView {

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -1,7 +1,9 @@
 //! Extensions to the core library.
 
 mod pool_manager_lens;
+mod position;
 mod simple_tick_data_provider;
 
 pub use pool_manager_lens::PoolManagerLens;
+pub use position::*;
 pub use simple_tick_data_provider::SimpleTickDataProvider;

--- a/src/extensions/position.rs
+++ b/src/extensions/position.rs
@@ -1,0 +1,164 @@
+//! Position utilities for parsing identifiers from V4 transactions and events.
+//!
+//! This module provides functionality to extract both position keys and NFT token IDs from Uniswap
+//! V4 transactions. Position keys are derived from ModifyLiquidity events and used for pool manager
+//! queries, while NFT token IDs come from ERC721 Transfer events and are used for position manager
+//! operations.
+
+use crate::prelude::{calculate_position_key, Error, ModifyLiquidity, Transfer};
+use alloc::vec::Vec;
+use alloy::{
+    eips::BlockNumberOrTag,
+    network::Network,
+    providers::Provider,
+    rpc::types::{Filter, TransactionReceipt},
+};
+use alloy_primitives::{Address, B256, U256};
+use alloy_sol_types::SolEvent;
+
+/// Extracts position keys from ModifyLiquidity events in a specific transaction.
+///
+/// This function looks for ModifyLiquidity events in the given transaction receipt
+/// and extracts position keys from events that represent new positions (positive liquidityDelta).
+///
+/// ## Arguments
+///
+/// * `pool_manager` - The address of the V4 pool manager contract
+/// * `tx_receipt` - The transaction receipt containing the logs
+///
+/// ## Returns
+///
+/// A vector of position keys (as B256) that were created in the transaction.
+#[inline]
+#[must_use]
+pub fn get_position_keys_from_transaction(
+    pool_manager: Address,
+    tx_receipt: &TransactionReceipt,
+) -> Vec<B256> {
+    tx_receipt
+        .logs()
+        .iter()
+        .filter(|&log| log.address() == pool_manager)
+        .filter(|&log| {
+            log.topic0()
+                .map(|topic| topic == &ModifyLiquidity::SIGNATURE_HASH)
+                .unwrap_or(false)
+        })
+        .filter_map(|log| ModifyLiquidity::decode_log_data(log.data()).ok())
+        .filter(|event| event.liquidityDelta.is_positive())
+        .map(|event| {
+            calculate_position_key(event.sender, event.tickLower, event.tickUpper, event.salt)
+        })
+        .collect()
+}
+
+/// Extracts position keys from ModifyLiquidity events within a block range.
+///
+/// This function searches for ModifyLiquidity events in a range of blocks for a specific
+/// pool and extracts position keys from events that represent new positions (positive
+/// liquidityDelta).
+///
+/// ## Arguments
+///
+/// * `pool_manager` - The address of the V4 pool manager contract
+/// * `pool_id` - The ID of the pool to filter events for
+/// * `from_block` - The starting block for the search
+/// * `to_block` - The ending block for the search
+/// * `provider` - The provider instance for blockchain queries
+///
+/// ## Returns
+///
+/// A vector of position keys (as B256) that were created in the specified block range.
+#[inline]
+pub async fn get_position_keys_in_blocks<P, N>(
+    pool_manager: Address,
+    pool_id: B256,
+    from_block: BlockNumberOrTag,
+    to_block: BlockNumberOrTag,
+    provider: P,
+) -> Result<Vec<B256>, Error>
+where
+    P: Provider<N>,
+    N: Network,
+{
+    let filter = Filter::new()
+        .from_block(from_block)
+        .to_block(to_block)
+        .event_signature(ModifyLiquidity::SIGNATURE_HASH)
+        .address(pool_manager)
+        .topic1(pool_id);
+
+    let logs = provider
+        .get_logs(&filter)
+        .await
+        .map_err(|e| Error::ContractError(e.into()))?;
+
+    let position_keys: Vec<B256> = logs
+        .iter()
+        .filter_map(|log| ModifyLiquidity::decode_log_data(log.data()).ok())
+        .filter(|event| event.liquidityDelta.is_positive())
+        .map(|event| {
+            calculate_position_key(event.sender, event.tickLower, event.tickUpper, event.salt)
+        })
+        .collect();
+
+    Ok(position_keys)
+}
+
+/// Extracts all NFT token IDs and their recipients from a position manager transaction.
+///
+/// This function looks for ERC721 Transfer events in the given transaction receipt
+/// from the position manager contract, specifically minting events (from address(0)).
+/// Returns all minted token IDs with their respective recipients.
+///
+/// ## Arguments
+///
+/// * `position_manager` - The address of the V4 position manager contract
+/// * `tx_receipt` - The transaction receipt containing the logs
+///
+/// ## Returns
+///
+/// A vector of (recipient, token_id) pairs for all NFTs minted in the transaction.
+#[inline]
+#[must_use]
+pub fn get_token_ids_from_transaction(
+    position_manager: Address,
+    tx_receipt: &TransactionReceipt,
+) -> Vec<(Address, U256)> {
+    tx_receipt
+        .logs()
+        .iter()
+        .filter(|&log| log.address() == position_manager)
+        .filter(|&log| {
+            log.topic0()
+                .map(|topic| topic == &Transfer::SIGNATURE_HASH)
+                .unwrap_or(false)
+        })
+        .filter_map(|log| Transfer::decode_log_data(log.data()).ok())
+        .filter(|event| event.from.is_zero()) // Minting: from == address(0)
+        .map(|event| (event.to, event.tokenId))
+        .collect()
+}
+
+/// Extracts the first NFT token ID from a position manager mint transaction.
+///
+/// This is a convenience function that returns only the first minted token ID,
+/// maintaining backward compatibility with code that expects a single token ID.
+///
+/// ## Arguments
+///
+/// * `position_manager` - The address of the V4 position manager contract
+/// * `tx_receipt` - The transaction receipt containing the logs
+///
+/// ## Returns
+///
+/// An optional NFT token ID (as U256) for the first token minted in the transaction.
+#[inline]
+#[must_use]
+pub fn get_first_token_id_from_transaction(
+    position_manager: Address,
+    tx_receipt: &TransactionReceipt,
+) -> Option<U256> {
+    let token_ids = get_token_ids_from_transaction(position_manager, tx_receipt);
+    token_ids.first().map(|(_, token_id)| *token_id)
+}

--- a/src/extensions/position.rs
+++ b/src/extensions/position.rs
@@ -39,11 +39,7 @@ pub fn get_position_keys_from_transaction(
         .logs()
         .iter()
         .filter(|&log| log.address() == pool_manager)
-        .filter(|&log| {
-            log.topic0()
-                .map(|topic| topic == &ModifyLiquidity::SIGNATURE_HASH)
-                .unwrap_or(false)
-        })
+        .filter(|&log| matches!(log.topic0(), Some(t) if t == &ModifyLiquidity::SIGNATURE_HASH))
         .filter_map(|log| ModifyLiquidity::decode_log_data(log.data()).ok())
         .filter(|event| event.liquidityDelta.is_positive())
         .map(|event| {
@@ -129,11 +125,7 @@ pub fn get_token_ids_from_transaction(
         .logs()
         .iter()
         .filter(|&log| log.address() == position_manager)
-        .filter(|&log| {
-            log.topic0()
-                .map(|topic| topic == &Transfer::SIGNATURE_HASH)
-                .unwrap_or(false)
-        })
+        .filter(|&log| matches!(log.topic0(), Some(t) if t == &Transfer::SIGNATURE_HASH))
         .filter_map(|log| Transfer::decode_log_data(log.data()).ok())
         .filter(|event| event.from.is_zero()) // Minting: from == address(0)
         .map(|event| (event.to, event.tokenId))

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -146,7 +146,7 @@ mod extensions {
     use super::*;
     use crate::abi::IStateView;
     use alloy::{
-        eips::{BlockId, BlockNumberOrTag},
+        eips::BlockId,
         providers::{ProviderBuilder, RootProvider},
         transports::http::reqwest::Url,
     };
@@ -162,8 +162,7 @@ mod extensions {
             .connect_http(RPC_URL.clone())
     });
 
-    pub(crate) const BLOCK_ID: Option<BlockId> =
-        Some(BlockId::Number(BlockNumberOrTag::Number(22305544)));
+    pub(crate) const BLOCK_ID: Option<BlockId> = Some(BlockId::number(22305544));
 
     pub(crate) static POOL_ID_ETH_USDC: Lazy<B256> = Lazy::new(|| {
         Pool::get_pool_id(


### PR DESCRIPTION
- Added `position.rs` module for position key extraction from `ModifyLiquidity` events.
- Implemented NFT token ID extraction from `Transfer` events in position manager transactions.
- Refactored position ID references to position keys for consistency.
- Streamlined `BlockId` handling with `BlockId::latest()` for clarity.
- Bumped version to 0.11.0 in `Cargo.toml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Utilities to extract position keys from transactions or block ranges and to read minted NFT token IDs from transactions.
  - ABI events added to support position/liquidity changes and NFT transfers.

- Refactor
  - Lens APIs renamed to use position_key (vs position_id); on-chain reads default to latest BlockId.
  - Extensions module exposes new position utilities.

- Tests
  - Tests updated to use key-based flows and new utilities.

- Documentation
  - References updated from “position ID” to “position key.”

- Chores
  - Package version and dependency bumps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->