### PR TITLE
doc: refactor and modularize examples with shared utilities

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,6 @@ alloy-primitives = { version = "1.3", default-features = false }
 alloy-sol-types = { version = "1.3", default-features = false }
 derive_more = { version = "2", default-features = false, features = ["deref", "deref_mut", "from"] }
 num-traits = { version = "0.2", default-features = false, features = ["libm"] }
-once_cell = { version = "1.21", optional = true }
-dotenv = { version = "0.15", optional = true }
 thiserror = { version = "2", default-features = false }
 uniswap-sdk-core = "5.2.0"
 uniswap-v3-sdk = "5.2.0"
@@ -47,19 +45,11 @@ extensions = [
     "alloy",
     "uniswap-v3-sdk/extensions"
 ]
-test-utils = [
-    "alloy/provider-anvil-node",
-    "alloy/reqwest",
-    "alloy/signer-local",
-    "dotenv",
-    "once_cell",
-    "std"
-]
 
 [[example]]
 name = "mint_position_basic"
-required-features = ["extensions", "test-utils"]
+required-features = ["extensions"]
 
 [[example]]
 name = "mint_position_permit2"
-required-features = ["extensions", "test-utils"]
+required-features = ["extensions"]

--- a/examples/README.md
+++ b/examples/README.md
@@ -34,26 +34,19 @@ cargo build --features extensions
 - **[mint_position_permit2.rs](./mint_position_permit2.rs)** - Demonstrates using Permit2 for gasless token approvals
   when minting positions
 
-- **[mint_position_create_pool.rs](./mint_position_create_pool.rs)** - Shows how to create a new V4 pool and mint a
-  position in the same transaction
-
 ## Running Examples
 
 Each example can be run independently:
 
 ```bash
 # Run the basic minting example
-cargo run --example mint_position_basic --features extensions,test-utils
-
-# Run the create pool + mint example  
-cargo run --example mint_position_create_pool --features extensions,test-utils
+cargo run --example mint_position_basic --features extensions
 
 # Run the permit2 example
-cargo run --example mint_position_permit2 --features extensions,test-utils
+cargo run --example mint_position_permit2 --features extensions
 ```
 
-**Note**: Examples require both `extensions` (for V4 functionality) and `test-utils` (for test tokens and helper
-functions) features.
+**Note**: Examples require the `extensions` feature for V4 functionality.
 
 ## Key Concepts
 
@@ -83,13 +76,7 @@ All examples use Anvil forking to create a local testnet that mirrors the mainne
 ## Common Patterns
 
 - Use `uniswap_v4_sdk::prelude::*` for easy imports
-- Import test utilities with `use uniswap_v4_sdk::tests::*` (requires `test-utils` feature)
+- Use shared utilities from `examples/common` module
 - Set up Anvil provider for local testing
 - Handle both native ETH and ERC20 tokens as currencies
 - Use appropriate slippage tolerance and deadline parameters
-
-## Features
-
-- **`extensions`**: Core V4 functionality including `PoolManagerLens` and RPC capabilities
-- **`test-utils`**: Test tokens, helper functions, and utilities for examples and testing (includes `once_cell`,
-  `dotenv`, `std`)

--- a/examples/common/constants.rs
+++ b/examples/common/constants.rs
@@ -1,0 +1,23 @@
+//! Common constants used across examples
+
+use alloy::{eips::BlockId, transports::http::reqwest::Url};
+use alloy_primitives::{address, Address};
+use once_cell::sync::Lazy;
+use uniswap_sdk_core::addresses::CHAIN_TO_ADDRESSES_MAP;
+
+pub static RPC_URL: Lazy<Url> = Lazy::new(|| {
+    dotenv::dotenv().ok();
+    std::env::var("MAINNET_RPC_URL").unwrap().parse().unwrap()
+});
+
+pub const BLOCK_ID: Option<BlockId> = Some(BlockId::number(22305544));
+
+pub const PERMIT2_ADDRESS: Address = address!("000000000022D473030F116dDEE9F6B43aC78BA3");
+
+static V4_ADDRESSES: Lazy<&uniswap_sdk_core::addresses::ChainAddresses> =
+    Lazy::new(|| CHAIN_TO_ADDRESSES_MAP.get(&1).unwrap());
+
+pub static V4_POSITION_MANAGER: Lazy<Address> =
+    Lazy::new(|| V4_ADDRESSES.v4_position_manager.unwrap());
+
+pub static V4_POOL_MANAGER: Lazy<Address> = Lazy::new(|| V4_ADDRESSES.v4_pool_manager.unwrap());

--- a/examples/common/helpers.rs
+++ b/examples/common/helpers.rs
@@ -1,0 +1,114 @@
+//! Common helper functions for examples
+
+use super::{constants::PERMIT2_ADDRESS, tokens::ETHER};
+use alloy::{
+    providers::{ext::AnvilApi, Provider},
+    signers::{local::PrivateKeySigner, SignerSync},
+    sol_types::{eip712_domain, Eip712Domain, SolStruct},
+};
+use alloy_primitives::{aliases::U24, Address, Bytes, Signature, B256, U256};
+use uniswap_sdk_core::prelude::*;
+use uniswap_v3_sdk::prelude::*;
+use uniswap_v4_sdk::{
+    entities::Pool,
+    extensions::PoolManagerLens,
+    position_manager::{AddLiquidityOptions, AddLiquiditySpecificOptions, MintSpecificOptions},
+    prelude::{Error, *},
+};
+
+/// Create a pool from on-chain state
+#[inline]
+pub async fn create_pool(
+    provider: &impl Provider,
+    v4_pool_manager: Address,
+    currency0: Currency,
+    currency1: Currency,
+    fee: U24,
+    tick_spacing: i32,
+    hook_address: Address,
+) -> Result<Pool, Error> {
+    let pool_id = Pool::get_pool_id(&currency0, &currency1, fee, tick_spacing, hook_address)?;
+
+    let pool_lens = PoolManagerLens::new(v4_pool_manager, provider);
+    let (actual_sqrt_price, _, _, _) = pool_lens.get_slot0(pool_id, None).await?;
+
+    Pool::new(
+        currency0,
+        currency1,
+        fee,
+        tick_spacing,
+        hook_address,
+        actual_sqrt_price,
+        0,
+    )
+}
+
+/// Setup token balance and approval for a single token
+#[inline]
+pub async fn setup_token_balance(
+    provider: &impl Provider,
+    token_address: Address,
+    account: Address,
+    amount: U256,
+    approve_to: Address,
+) -> Result<(), Error> {
+    let overrides =
+        get_erc20_state_overrides(token_address, account, approve_to, amount, provider).await?;
+
+    for (token, account_override) in overrides {
+        for (slot, value) in account_override.state_diff.unwrap() {
+            provider
+                .anvil_set_storage_at(token, U256::from_be_bytes(slot.0), value)
+                .await
+                .unwrap();
+        }
+    }
+
+    Ok(())
+}
+
+/// Get Permit2 EIP-712 domain for mainnet
+#[inline]
+#[must_use]
+pub const fn get_permit2_domain() -> Eip712Domain {
+    eip712_domain! {
+        name: "Permit2",
+        chain_id: 1,
+        verifying_contract: PERMIT2_ADDRESS,
+    }
+}
+
+/// Create EIP-712 signature for Permit2 batch permit
+#[inline]
+pub fn create_permit2_signature(
+    permit_batch: &AllowanceTransferPermitBatch,
+    signer: &PrivateKeySigner,
+) -> Bytes {
+    let domain = get_permit2_domain();
+    let hash: B256 = permit_batch.eip712_signing_hash(&domain);
+    let signature: Signature = signer.sign_hash_sync(&hash).unwrap();
+    signature.as_bytes().into()
+}
+
+/// Create AddLiquidityOptions for minting positions
+#[inline]
+pub fn create_add_liquidity_options(
+    recipient: Address,
+    batch_permit: Option<BatchPermitOptions>,
+) -> AddLiquidityOptions {
+    AddLiquidityOptions {
+        common_opts: CommonOptions {
+            slippage_tolerance: Percent::new(1, 1000),
+            deadline: U256::MAX,
+            hook_data: Default::default(),
+        },
+        use_native: Some(ETHER.clone()),
+        batch_permit,
+        specific_opts: AddLiquiditySpecificOptions::Mint(MintSpecificOptions {
+            recipient,
+            create_pool: false,
+            sqrt_price_x96: None,
+            migrate: false,
+        }),
+    }
+}

--- a/examples/common/mod.rs
+++ b/examples/common/mod.rs
@@ -1,0 +1,12 @@
+//! Common utilities and setup code for examples
+
+#![allow(dead_code)]
+pub mod constants;
+pub mod helpers;
+pub mod providers;
+pub mod tokens;
+
+pub use constants::*;
+pub use helpers::*;
+pub use providers::*;
+pub use tokens::*;

--- a/examples/common/providers.rs
+++ b/examples/common/providers.rs
@@ -1,0 +1,25 @@
+//! Common provider setup utilities for examples
+
+use super::constants::RPC_URL;
+use alloy::{
+    providers::{ext::AnvilApi, Provider, ProviderBuilder},
+    signers::local::PrivateKeySigner,
+};
+use alloy_primitives::U256;
+
+/// Set up an Anvil fork from mainnet at a specific block
+#[inline]
+pub fn setup_anvil_fork(fork_block: u64) -> impl Provider + Clone {
+    ProviderBuilder::new().connect_anvil_with_config(|anvil| {
+        anvil.fork(RPC_URL.clone()).fork_block_number(fork_block)
+    })
+}
+
+/// Create a test account with ETH balance
+#[inline]
+pub async fn setup_test_account(provider: &impl Provider, balance: U256) -> PrivateKeySigner {
+    let signer = PrivateKeySigner::random();
+    let account = signer.address();
+    provider.anvil_set_balance(account, balance).await.unwrap();
+    signer
+}

--- a/examples/common/tokens.rs
+++ b/examples/common/tokens.rs
@@ -1,0 +1,28 @@
+//! Common token definitions used across examples
+
+use once_cell::sync::Lazy;
+use uniswap_sdk_core::{prelude::*, token};
+
+pub static ETHER: Lazy<Ether> = Lazy::new(|| Ether::on_chain(1));
+
+pub static USDC: Lazy<Token> = Lazy::new(|| {
+    token!(
+        1,
+        "A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+        6,
+        "USDC",
+        "USD Coin"
+    )
+});
+
+pub static DAI: Lazy<Token> = Lazy::new(|| {
+    token!(
+        1,
+        "6B175474E89094C44Da98b954EedeAC495271d0F",
+        18,
+        "DAI",
+        "DAI Stablecoin"
+    )
+});
+
+pub static WETH: Lazy<Token> = Lazy::new(|| ETHER.wrapped().clone());

--- a/examples/mint_position_basic.rs
+++ b/examples/mint_position_basic.rs
@@ -8,38 +8,29 @@ use alloy_primitives::{aliases::U48, U160};
 use alloy_sol_types::SolCall;
 use uniswap_sdk_core::prelude::*;
 use uniswap_v3_sdk::prelude::{nearest_usable_tick, FeeAmount, MintAmounts};
-use uniswap_v4_sdk::{prelude::*, tests::*};
+use uniswap_v4_sdk::{extensions::get_first_token_id_from_transaction, prelude::*};
+
+#[path = "common/mod.rs"]
+mod common;
+use common::*;
 
 const TICK_SPACING: i32 = 10;
 const LIQUIDITY_AMOUNT: u128 = 1_000_000_000_000_000;
 
-/// Basic example demonstrating how to mint a liquidity position in an existing Uniswap V4 pool.
-/// This example:
-/// 1. Sets up a forked mainnet environment using Anvil
-/// 2. Checks if an ETH-USDC V4 pool exists and gets its current state
-/// 3. Sets up token balances and Permit2 approvals (required for V4)
-/// 4. Mints a liquidity position in the pool
-/// 5. Verifies the position was created correctly
+/// Basic example demonstrating how to mint a liquidity position in an existing Uniswap V4 pool
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Use a recent block for forking
     let block_id = 22808980;
 
-    println!("🔗 Setting up Anvil fork from mainnet...");
-    let provider = setup_anvil_fork(block_id).await;
+    let provider = setup_anvil_fork(block_id);
     provider.anvil_auto_impersonate_account(true).await.unwrap();
-
-    println!("👤 Creating test account...");
     let signer = setup_test_account(&provider, WEI_IN_ETHER).await;
     let account = signer.address();
-    println!("👤 Created test account: {account}");
 
-    // Get V4 contract addresses
-    let chain_addresses = CHAIN_TO_ADDRESSES_MAP.get(&1).unwrap();
-    let v4_position_manager = chain_addresses.v4_position_manager.unwrap();
-    let v4_pool_manager = chain_addresses.v4_pool_manager.unwrap();
+    let v4_position_manager = *V4_POSITION_MANAGER;
+    let v4_pool_manager = *V4_POOL_MANAGER;
 
-    println!("🔍 Setting up ETH-USDC pool...");
     let pool = create_pool(
         &provider,
         v4_pool_manager,
@@ -51,27 +42,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     )
     .await?;
 
-    println!(
-        "✅ Pool found: {} / {}",
-        pool.currency0.symbol().unwrap(),
-        pool.currency1.symbol().unwrap()
-    );
-
-    println!("📍 V4 Position Manager: {v4_position_manager}");
-
     let tick_lower = nearest_usable_tick(pool.tick_current - TICK_SPACING * 10, TICK_SPACING);
     let tick_upper = nearest_usable_tick(pool.tick_current + TICK_SPACING * 10, TICK_SPACING);
 
-    println!("📊 Position parameters:");
-    println!("  - Tick range: {tick_lower} to {tick_upper}");
-    println!("  - Liquidity: {LIQUIDITY_AMOUNT}");
-
     let mut position = Position::new(pool, LIQUIDITY_AMOUNT, tick_lower, tick_upper);
     let MintAmounts { amount0, amount1 } = position.mint_amounts()?;
-
-    println!("💰 Required amounts:");
-    println!("  - Amount0 (ETH): {amount0}");
-    println!("  - Amount1 (USDC): {amount1}");
 
     // Set up token balances and Permit2 approvals
     setup_token_balance(&provider, USDC.address(), account, amount1, PERMIT2_ADDRESS).await?;
@@ -83,10 +58,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         PERMIT2_ADDRESS,
     )
     .await?;
-    println!("💳 Token balances and Permit2 approvals set up");
-
-    // Approve v4_position_manager on Permit2 for USDC transfers (V4 requirement)
-    println!("🔐 Approving v4_position_manager on Permit2...");
 
     let approve_call = IAllowanceTransfer::approveCall {
         token: USDC.address(),
@@ -101,17 +72,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_input(approve_call.abi_encode());
 
     provider.send_transaction(approve_tx).await?.watch().await?;
-    println!("✅ Permit2 approval successful");
-
-    println!("🚀 Minting position...");
 
     let options = create_add_liquidity_options(account, None);
-
     let params = add_call_parameters(&mut position, options)?;
-
-    println!("📋 Transaction details:");
-    println!("  - Calldata length: {} bytes", params.calldata.len());
-    println!("  - Value: {} wei", params.value);
 
     let tx = TransactionRequest::default()
         .with_from(account)
@@ -119,11 +82,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_input(params.calldata)
         .with_value(params.value);
 
-    let receipt = provider.send_transaction(tx).await?.watch().await?;
+    let tx_hash = provider.send_transaction(tx).await?.watch().await?;
+    let receipt = provider.get_transaction_receipt(tx_hash).await?.unwrap();
+    let token_id = get_first_token_id_from_transaction(v4_position_manager, &receipt).unwrap();
+    println!("Position minted with token ID: {token_id}");
 
-    println!("✅ Position minted successfully!");
-    println!("📋 Transaction hash: {receipt:?}");
-
-    // In a real application, parse logs to get token ID and verify position
     Ok(())
 }

--- a/examples/mint_position_permit2.rs
+++ b/examples/mint_position_permit2.rs
@@ -7,39 +7,29 @@ use alloy::{
 use alloy_primitives::aliases::U48;
 use uniswap_sdk_core::prelude::*;
 use uniswap_v3_sdk::prelude::{nearest_usable_tick, FeeAmount, MintAmounts};
-use uniswap_v4_sdk::{prelude::*, tests::*};
+use uniswap_v4_sdk::{extensions::get_first_token_id_from_transaction, prelude::*};
+
+#[path = "common/mod.rs"]
+mod common;
+use common::*;
 
 const TICK_SPACING: i32 = 10;
 const LIQUIDITY_AMOUNT: u128 = 1_000_000_000_000_000;
 
-/// Permit2 example demonstrating gasless token approvals when minting positions.
-/// This example:
-/// 1. Sets up a forked mainnet environment using Anvil
-/// 2. Checks if an ETH-USDC V4 pool exists and gets its current state
-/// 3. Sets up token balances (no direct Permit2 approvals needed)
-/// 4. Creates EIP-712 signatures for gasless token approvals via Permit2
-/// 5. Mints a liquidity position using the gasless approvals
-/// 6. Verifies the position was created correctly
+/// Example demonstrating gasless token approvals with Permit2 when minting positions
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Use a recent block for forking
     let block_id = 22808980;
 
-    println!("🔗 Setting up Anvil fork from mainnet...");
-    let provider = setup_anvil_fork(block_id).await;
+    let provider = setup_anvil_fork(block_id);
     provider.anvil_auto_impersonate_account(true).await.unwrap();
-
-    println!("👤 Creating test account...");
     let signer = setup_test_account(&provider, WEI_IN_ETHER).await;
     let account = signer.address();
-    println!("👤 Created test account: {account}");
 
-    // Get V4 contract addresses
-    let chain_addresses = CHAIN_TO_ADDRESSES_MAP.get(&1).unwrap();
-    let v4_position_manager = chain_addresses.v4_position_manager.unwrap();
-    let v4_pool_manager = chain_addresses.v4_pool_manager.unwrap();
+    let v4_position_manager = *V4_POSITION_MANAGER;
+    let v4_pool_manager = *V4_POOL_MANAGER;
 
-    println!("🔍 Setting up ETH-USDC pool...");
     let pool = create_pool(
         &provider,
         v4_pool_manager,
@@ -51,27 +41,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     )
     .await?;
 
-    println!(
-        "✅ Pool found: {} / {}",
-        pool.currency0.symbol().unwrap(),
-        pool.currency1.symbol().unwrap()
-    );
-
-    println!("📍 V4 Position Manager: {v4_position_manager}");
-
     let tick_lower = nearest_usable_tick(pool.tick_current - TICK_SPACING * 10, TICK_SPACING);
     let tick_upper = nearest_usable_tick(pool.tick_current + TICK_SPACING * 10, TICK_SPACING);
 
-    println!("📊 Position parameters:");
-    println!("  - Tick range: {tick_lower} to {tick_upper}");
-    println!("  - Liquidity: {LIQUIDITY_AMOUNT}");
-
     let mut position = Position::new(pool, LIQUIDITY_AMOUNT, tick_lower, tick_upper);
     let MintAmounts { amount0, amount1 } = position.mint_amounts()?;
-
-    println!("💰 Required amounts:");
-    println!("  - Amount0 (ETH): {amount0}");
-    println!("  - Amount1 (USDC): {amount1}");
 
     // Set up token balances and approve to Permit2 (required before using Permit2 signatures)
     setup_token_balance(&provider, USDC.address(), account, amount1, PERMIT2_ADDRESS).await?;
@@ -83,10 +57,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         PERMIT2_ADDRESS,
     )
     .await?;
-    println!("💳 Token balances and Permit2 approvals set up");
-
-    // Create Permit2 batch permit data for gasless approvals
-    println!("🔐 Creating Permit2 batch permit signature...");
 
     let permit_batch = position.permit_batch_data(
         &Percent::new(1, 1000), // 0.1% slippage
@@ -95,19 +65,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         U48::MAX,   // deadline
     )?;
 
-    println!("📋 Permit batch details:");
-    println!("  - Token0: {}", permit_batch.details[0].token);
-    println!("  - Amount0: {}", permit_batch.details[0].amount);
-    println!("  - Token1: {}", permit_batch.details[1].token);
-    println!("  - Amount1: {}", permit_batch.details[1].amount);
-    println!("  - Spender: {}", permit_batch.spender);
-
-    // Create EIP-712 signature for the permit batch
-    let signature = create_permit2_signature(&permit_batch, &signer)?;
-
-    println!("✅ Permit2 signature created (gasless approval)");
-
-    println!("🚀 Minting position with gasless approvals...");
+    let signature = create_permit2_signature(&permit_batch, &signer);
 
     let options = create_add_liquidity_options(
         account,
@@ -120,22 +78,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let params = add_call_parameters(&mut position, options)?;
 
-    println!("📋 Transaction details:");
-    println!("  - Calldata length: {} bytes", params.calldata.len());
-    println!("  - Value: {} wei", params.value);
-    println!("  - Includes gasless Permit2 approval");
-
     let tx = TransactionRequest::default()
         .with_from(account)
         .with_to(v4_position_manager)
         .with_input(params.calldata)
         .with_value(params.value);
 
-    let receipt = provider.send_transaction(tx).await?.watch().await?;
-
-    println!("✅ Position minted successfully with gasless approvals!");
-    println!("📋 Transaction hash: {receipt:?}");
-    println!("🎉 No separate approval transactions were needed!");
+    let tx_hash = provider.send_transaction(tx).await?.watch().await?;
+    let receipt = provider.get_transaction_receipt(tx_hash).await?.unwrap();
+    let token_id = get_first_token_id_from_transaction(v4_position_manager, &receipt).unwrap();
+    println!("Position minted with gasless approvals, token ID: {token_id}");
 
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,8 +37,8 @@ pub use uniswap_v3_sdk::multicall;
 #[cfg(feature = "extensions")]
 pub mod extensions;
 
-#[cfg(any(test, feature = "test-utils"))]
-pub mod tests;
+#[cfg(test)]
+mod tests;
 
 pub mod prelude {
     pub use crate::{abi::*, entities::*, error::*, multicall::*, position_manager::*, utils::*};

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -8,13 +8,13 @@ use once_cell::sync::Lazy;
 use uniswap_sdk_core::{prelude::*, token};
 use uniswap_v3_sdk::prelude::*;
 
-pub const PERMIT2_ADDRESS: Address = address!("000000000022D473030F116dDEE9F6B43aC78BA3");
+pub(crate) const PERMIT2_ADDRESS: Address = address!("000000000022D473030F116dDEE9F6B43aC78BA3");
 
-pub static ETHER: Lazy<Ether> = Lazy::new(|| Ether::on_chain(1));
+pub(crate) static ETHER: Lazy<Ether> = Lazy::new(|| Ether::on_chain(1));
 
 pub(crate) static WETH: Lazy<Token> = Lazy::new(|| ETHER.wrapped().clone());
 
-pub static USDC: Lazy<Token> = Lazy::new(|| {
+pub(crate) static USDC: Lazy<Token> = Lazy::new(|| {
     token!(
         1,
         "A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
@@ -186,151 +186,4 @@ mod extensions {
                 PROVIDER.clone(),
             )
         });
-}
-
-#[cfg(all(feature = "extensions", feature = "test-utils"))]
-pub use examples::*;
-
-#[cfg(all(feature = "extensions", feature = "test-utils"))]
-mod examples {
-    use super::*;
-    use crate::{
-        position_manager::{AddLiquidityOptions, AddLiquiditySpecificOptions, MintSpecificOptions},
-        prelude::*,
-    };
-    use alloc::boxed::Box;
-    use alloy::{
-        providers::{
-            ext::AnvilApi,
-            fillers::{
-                BlobGasFiller, ChainIdFiller, FillProvider, GasFiller, JoinFill, NonceFiller,
-            },
-            layers::AnvilProvider,
-            Identity, Provider, ProviderBuilder, RootProvider,
-        },
-        signers::{local::PrivateKeySigner, SignerSync},
-    };
-    use alloy_primitives::{aliases::U24, Bytes, Signature, B256, U256};
-    use alloy_sol_types::{eip712_domain, Eip712Domain, SolStruct};
-
-    /// Set up an Anvil fork from mainnet at a specific block
-    #[inline]
-    pub async fn setup_anvil_fork(
-        fork_block: u64,
-    ) -> FillProvider<
-        JoinFill<
-            Identity,
-            JoinFill<GasFiller, JoinFill<BlobGasFiller, JoinFill<NonceFiller, ChainIdFiller>>>,
-        >,
-        AnvilProvider<RootProvider>,
-    > {
-        ProviderBuilder::new().connect_anvil_with_config(|anvil| {
-            anvil.fork(RPC_URL.clone()).fork_block_number(fork_block)
-        })
-    }
-
-    /// Create a test account with ETH balance
-    #[inline]
-    pub async fn setup_test_account(provider: &impl Provider, balance: U256) -> PrivateKeySigner {
-        let signer = PrivateKeySigner::random();
-        let account = signer.address();
-        provider.anvil_set_balance(account, balance).await.unwrap();
-        signer
-    }
-
-    /// Create a pool from on-chain state
-    #[inline]
-    pub async fn create_pool(
-        provider: &impl Provider,
-        v4_pool_manager: Address,
-        currency0: Currency,
-        currency1: Currency,
-        fee: U24,
-        tick_spacing: i32,
-        hook_address: Address,
-    ) -> Result<Pool, Box<dyn core::error::Error>> {
-        let pool_id = Pool::get_pool_id(&currency0, &currency1, fee, tick_spacing, hook_address)?;
-
-        let pool_lens = PoolManagerLens::new(v4_pool_manager, provider);
-        let (actual_sqrt_price, _, _, _) = pool_lens.get_slot0(pool_id, None).await?;
-
-        Ok(Pool::new(
-            currency0,
-            currency1,
-            fee,
-            tick_spacing,
-            hook_address,
-            actual_sqrt_price,
-            0,
-        )?)
-    }
-
-    /// Setup token balance and approval for a single token
-    #[inline]
-    pub async fn setup_token_balance(
-        provider: &impl Provider,
-        token_address: Address,
-        account: Address,
-        amount: U256,
-        approve_to: Address,
-    ) -> Result<(), Box<dyn core::error::Error>> {
-        let overrides =
-            get_erc20_state_overrides(token_address, account, approve_to, amount, provider).await?;
-
-        for (token, account_override) in overrides {
-            for (slot, value) in account_override.state_diff.unwrap() {
-                provider
-                    .anvil_set_storage_at(token, U256::from_be_bytes(slot.0), value)
-                    .await?;
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Get Permit2 EIP-712 domain for mainnet
-    #[inline]
-    #[must_use]
-    pub const fn get_permit2_domain() -> Eip712Domain {
-        eip712_domain! {
-            name: "Permit2",
-            chain_id: 1,
-            verifying_contract: PERMIT2_ADDRESS,
-        }
-    }
-
-    /// Create EIP-712 signature for Permit2 batch permit
-    #[inline]
-    pub fn create_permit2_signature(
-        permit_batch: &AllowanceTransferPermitBatch,
-        signer: &PrivateKeySigner,
-    ) -> Result<Bytes, Box<dyn core::error::Error>> {
-        let domain = get_permit2_domain();
-        let hash: B256 = permit_batch.eip712_signing_hash(&domain);
-        let signature: Signature = signer.sign_hash_sync(&hash)?;
-        Ok(signature.as_bytes().into())
-    }
-
-    /// Create AddLiquidityOptions for minting positions
-    #[inline]
-    pub fn create_add_liquidity_options(
-        recipient: Address,
-        batch_permit: Option<BatchPermitOptions>,
-    ) -> AddLiquidityOptions {
-        AddLiquidityOptions {
-            common_opts: CommonOptions {
-                slippage_tolerance: Percent::new(1, 1000),
-                deadline: U256::MAX,
-                hook_data: Default::default(),
-            },
-            use_native: Some(ETHER.clone()),
-            batch_permit,
-            specific_opts: AddLiquiditySpecificOptions::Mint(MintSpecificOptions {
-                recipient,
-                create_pool: false,
-                sqrt_price_x96: None,
-                migrate: false,
-            }),
-        }
-    }
 }


### PR DESCRIPTION
- Moved reusable logic (e.g., Anvil setup, token management) into `examples/common`.
- Simplified `mint_position_basic.rs` and `mint_position_permit2.rs` by utilizing shared helper modules.
- Removed `dotenv` and `once_cell` from dependencies; replaced with centralized constants.
- Updated tests to eliminate `test-utils` feature, improving modularity.
- Adjusted `Cargo.toml` to reflect dependency changes and code restructure.