### PR TITLE
feat(examples): add increase liquidity example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,3 +53,7 @@ required-features = ["extensions"]
 [[example]]
 name = "mint_position_permit2"
 required-features = ["extensions"]
+
+[[example]]
+name = "increase_liquidity"
+required-features = ["extensions"]

--- a/examples/README.md
+++ b/examples/README.md
@@ -29,6 +29,11 @@ cargo build --features extensions
 - **[mint_position_basic.rs](./mint_position_basic.rs)** - Demonstrates minting a liquidity position in an existing
   ETH-USDC V4 pool
 
+### Liquidity Management Examples
+
+- **[increase_liquidity.rs](./increase_liquidity.rs)** - Shows how to add more tokens to an existing position,
+  demonstrating the complete workflow from initial mint to liquidity increase
+
 ### Advanced Examples
 
 - **[mint_position_permit2.rs](./mint_position_permit2.rs)** - Demonstrates using Permit2 for gasless token approvals
@@ -41,6 +46,9 @@ Each example can be run independently:
 ```bash
 # Run the basic minting example
 cargo run --example mint_position_basic --features extensions
+
+# Run the liquidity increase example
+cargo run --example increase_liquidity --features extensions
 
 # Run the permit2 example
 cargo run --example mint_position_permit2 --features extensions

--- a/examples/common/helpers.rs
+++ b/examples/common/helpers.rs
@@ -147,3 +147,23 @@ pub fn create_add_liquidity_options(
         }),
     }
 }
+
+/// Create AddLiquidityOptions for increasing liquidity in existing positions
+#[inline]
+pub fn create_increase_liquidity_options(
+    token_id: U256,
+    batch_permit: Option<BatchPermitOptions>,
+) -> AddLiquidityOptions {
+    AddLiquidityOptions {
+        common_opts: CommonOptions {
+            slippage_tolerance: Percent::new(1, 1000),
+            deadline: U256::MAX,
+            hook_data: Default::default(),
+        },
+        use_native: Some(ETHER.clone()),
+        batch_permit,
+        specific_opts: AddLiquiditySpecificOptions::Increase(ModifyPositionSpecificOptions {
+            token_id,
+        }),
+    }
+}

--- a/examples/increase_liquidity.rs
+++ b/examples/increase_liquidity.rs
@@ -1,0 +1,127 @@
+use alloy::{
+    network::TransactionBuilder,
+    node_bindings::WEI_IN_ETHER,
+    providers::{ext::AnvilApi, Provider},
+    rpc::types::TransactionRequest,
+};
+use uniswap_sdk_core::prelude::*;
+use uniswap_v3_sdk::prelude::{nearest_usable_tick, FeeAmount, MintAmounts};
+use uniswap_v4_sdk::{extensions::get_first_token_id_from_transaction, prelude::*};
+
+#[path = "common/mod.rs"]
+mod common;
+use common::*;
+
+const TICK_SPACING: i32 = 10;
+const INITIAL_LIQUIDITY: u128 = 500_000_000_000_000;
+const ADDITIONAL_LIQUIDITY: u128 = 300_000_000_000_000;
+
+/// Example demonstrating how to increase liquidity for an existing position
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Use a recent block for forking
+    let block_id = 22808980;
+
+    let provider = setup_anvil_fork(block_id);
+    provider.anvil_auto_impersonate_account(true).await.unwrap();
+    let signer = setup_test_account(&provider, WEI_IN_ETHER).await;
+    let account = signer.address();
+
+    // Get V4 contract addresses
+    let v4_position_manager = *V4_POSITION_MANAGER;
+    let v4_pool_manager = *V4_POOL_MANAGER;
+
+    let pool = create_pool(
+        &provider,
+        v4_pool_manager,
+        ETHER.clone().into(),
+        USDC.clone().into(),
+        FeeAmount::LOW.into(),
+        TICK_SPACING,
+        Address::ZERO,
+    )
+    .await?;
+
+    let tick_lower = nearest_usable_tick(pool.tick_current - TICK_SPACING * 10, TICK_SPACING);
+    let tick_upper = nearest_usable_tick(pool.tick_current + TICK_SPACING * 10, TICK_SPACING);
+
+    // STEP 1: MINT INITIAL POSITION
+
+    let mut initial_position =
+        Position::new(pool.clone(), INITIAL_LIQUIDITY, tick_lower, tick_upper);
+    let MintAmounts {
+        amount1: initial_amount1,
+        ..
+    } = initial_position.mint_amounts()?;
+
+    // Set up USDC balance with approval for initial mint
+    setup_token_and_approval(
+        &provider,
+        account,
+        v4_position_manager,
+        USDC.address(),
+        initial_amount1,
+    )
+    .await?;
+
+    let initial_options = create_add_liquidity_options(account, None);
+    let initial_params = add_call_parameters(&mut initial_position, initial_options)?;
+
+    let initial_tx = TransactionRequest::default()
+        .with_from(account)
+        .with_to(v4_position_manager)
+        .with_input(initial_params.calldata)
+        .with_value(initial_params.value);
+
+    let initial_tx_hash = provider.send_transaction(initial_tx).await?.watch().await?;
+
+    // Get the full transaction receipt to parse logs
+    let receipt = provider
+        .get_transaction_receipt(initial_tx_hash)
+        .await?
+        .unwrap();
+
+    // Parse the NFT token ID from transaction logs
+    let token_id = get_first_token_id_from_transaction(v4_position_manager, &receipt).unwrap();
+
+    // STEP 2: INCREASE LIQUIDITY
+
+    let mut additional_position =
+        Position::new(pool.clone(), ADDITIONAL_LIQUIDITY, tick_lower, tick_upper);
+    let MintAmounts {
+        amount1: additional_amount1,
+        ..
+    } = additional_position.mint_amounts()?;
+
+    // Set up additional USDC balance with approval for increase
+    setup_token_and_approval(
+        &provider,
+        account,
+        v4_position_manager,
+        USDC.address(),
+        additional_amount1,
+    )
+    .await?;
+
+    let increase_options = create_increase_liquidity_options(token_id, None);
+    let increase_params = add_call_parameters(&mut additional_position, increase_options)?;
+
+    let increase_tx = TransactionRequest::default()
+        .with_from(account)
+        .with_to(v4_position_manager)
+        .with_input(increase_params.calldata)
+        .with_value(increase_params.value);
+
+    provider
+        .send_transaction(increase_tx)
+        .await?
+        .watch()
+        .await?;
+
+    let total_liquidity = INITIAL_LIQUIDITY + ADDITIONAL_LIQUIDITY;
+    println!(
+        "Position {token_id}: liquidity increased from {INITIAL_LIQUIDITY} to {total_liquidity}"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
- Introduced `increase_liquidity.rs` example to demonstrate adding liquidity to an existing position.
- Updated `examples/README.md` with details and usage instructions for the new example.
- Adjusted `Cargo.toml` to register the new example configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a liquidity management example demonstrating minting a position and then increasing its liquidity, with clear before/after output.
  - Introduced a helper to simplify configuring liquidity increase within example workflows.
  - Enabled running the new example via the project manifest.

- Documentation
  - Updated the examples guide with an overview of the new liquidity increase example and step-by-step run instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->