### PR TITLE
fix: handle ETH-WETH route edges

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-v4-sdk"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2024"
 rust-version = "1.88"
 authors = ["Shuhui Luo <twitter.com/aureliano_law>"]

--- a/src/entities/route.rs
+++ b/src/entities/route.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 use alloc::vec::Vec;
 use alloy_primitives::ChainId;
-use uniswap_sdk_core::prelude::{BaseCurrency, Currency, Price};
+use uniswap_sdk_core::prelude::{BaseCurrency, BaseCurrencyCore, Currency, Price};
 use uniswap_v3_sdk::entities::TickDataProvider;
 
 /// Represents a list of pools through which a swap can occur
@@ -41,14 +41,28 @@ where
     pub fn new(pools: Vec<Pool<TP>>, input: TInput, output: TOutput) -> Result<Self, Error> {
         assert!(!pools.is_empty(), "POOLS");
 
-        let chain_id = pools[0].chain_id();
+        let first_pool = &pools[0];
+        let chain_id = first_pool.chain_id();
         let all_on_same_chain = pools.iter().all(|pool| pool.chain_id() == chain_id);
         assert!(all_on_same_chain, "CHAIN_IDS");
 
         // throws if pools do not involve the input and output currency or the native/wrapped
         // equivalent
-        let path_input = get_path_currency(&input, &pools[0])?;
+        let mut path_input = get_path_currency(&input, first_pool)?;
         let path_output = get_path_currency(&output, pools.last().unwrap())?;
+
+        // If the input is native and the first pool is an ETH-WETH pool, that means we already
+        // wrapped the input to WETH, so we need to set path_input to the wrapped input.
+        if first_pool.currency0.wrapped().equals(&first_pool.currency1)
+            && let Some(next_pool) = pools.get(1)
+        {
+            let next_pool_uses_native = next_pool.currency0.is_native();
+            if path_input.is_native() && next_pool_uses_native {
+                path_input = first_pool.currency1.clone();
+            } else if path_input.equals(&first_pool.currency1) && !next_pool_uses_native {
+                path_input = first_pool.currency0.clone();
+            }
+        }
 
         let mut current_input_currency = &path_input;
         for pool in &pools {
@@ -479,6 +493,60 @@ mod tests {
             assert_eq!(route.input, CURRENCY0.clone());
             assert_eq!(route.path_input, CURRENCY0.clone());
             assert_eq!(route.output, WETH.clone());
+            assert_eq!(route.path_output, ETHER.clone().into());
+        }
+
+        #[test]
+        fn supports_ether_input_with_eth_weth_first_pool_eth_second_pool() {
+            let route = create_route!(POOL_ETH_WETH, POOL_0_ETH; ETHER, CURRENCY0);
+            assert_eq!(route.input, ETHER.clone());
+            assert_eq!(route.path_input, WETH.clone().into());
+            assert_eq!(route.output, CURRENCY0.clone());
+            assert_eq!(route.path_output, CURRENCY0.clone());
+        }
+
+        #[test]
+        fn supports_weth_input_with_eth_weth_first_pool_weth_second_pool() {
+            let route = create_route!(POOL_ETH_WETH, POOL_0_WETH; WETH, CURRENCY0);
+            assert_eq!(route.input, WETH.clone());
+            assert_eq!(route.path_input, ETHER.clone().into());
+            assert_eq!(route.output, CURRENCY0.clone());
+            assert_eq!(route.path_output, CURRENCY0.clone());
+        }
+
+        #[test]
+        fn supports_ether_input_with_eth_weth_first_pool_weth_second_pool() {
+            let route = create_route!(POOL_ETH_WETH, POOL_0_WETH; ETHER, CURRENCY0);
+            assert_eq!(route.input, ETHER.clone());
+            assert_eq!(route.path_input, ETHER.clone().into());
+            assert_eq!(route.output, CURRENCY0.clone());
+            assert_eq!(route.path_output, CURRENCY0.clone());
+        }
+
+        #[test]
+        fn supports_weth_input_with_eth_weth_first_pool_eth_second_pool() {
+            let route = create_route!(POOL_ETH_WETH, POOL_0_ETH; WETH, CURRENCY0);
+            assert_eq!(route.input, WETH.clone());
+            assert_eq!(route.path_input, WETH.clone().into());
+            assert_eq!(route.output, CURRENCY0.clone());
+            assert_eq!(route.path_output, CURRENCY0.clone());
+        }
+
+        #[test]
+        fn eth_weth_eth_input() {
+            let route = create_route!(POOL_ETH_WETH, ETHER, WETH);
+            assert_eq!(route.input, ETHER.clone());
+            assert_eq!(route.path_input, ETHER.clone().into());
+            assert_eq!(route.output, WETH.clone());
+            assert_eq!(route.path_output, WETH.clone().into());
+        }
+
+        #[test]
+        fn eth_weth_weth_input() {
+            let route = create_route!(POOL_ETH_WETH, WETH, ETHER);
+            assert_eq!(route.input, WETH.clone());
+            assert_eq!(route.path_input, WETH.clone().into());
+            assert_eq!(route.output, ETHER.clone());
             assert_eq!(route.path_output, ETHER.clone().into());
         }
     }

--- a/src/entities/trade.rs
+++ b/src/entities/trade.rs
@@ -578,8 +578,37 @@ where
                 // Account for trades that wrap/unwrap as a last step
                 let mut token_amount =
                     amount_with_path_currency(&amount, route.pools.last().unwrap())?;
-                for pool in route.pools.iter().rev() {
+                for (i, pool) in route.pools.iter().enumerate().rev() {
                     (token_amount, _) = pool.get_input_amount(&token_amount, None).await?;
+                    let is_last_pool = i == route.pools.len() - 1;
+                    let is_eth_weth_pool = pool.currency1.equals(pool.currency0.wrapped());
+
+                    // Exact-output swaps walk pools backward. If the terminal pool is ETH-WETH,
+                    // retype the amount for the previous pool in route order: ETH for native
+                    // pools, or WETH for wrapped pools.
+                    if is_last_pool && is_eth_weth_pool {
+                        let previous_pool = i.checked_sub(1).and_then(|j| route.pools.get(j));
+                        let currency = previous_pool.and_then(|previous_pool| {
+                            let previous_pool_uses_native = previous_pool.currency0.is_native();
+                            if route.output.is_native() && previous_pool_uses_native {
+                                Some(pool.currency0.clone())
+                            } else if route.output.equals(&pool.currency1)
+                                && !previous_pool_uses_native
+                            {
+                                Some(pool.currency1.clone())
+                            } else {
+                                None
+                            }
+                        });
+
+                        if let Some(currency) = currency {
+                            token_amount = CurrencyAmount::from_fractional_amount(
+                                currency,
+                                token_amount.numerator,
+                                token_amount.denominator,
+                            )?;
+                        }
+                    }
                 }
                 input_amount = CurrencyAmount::from_fractional_amount(
                     route.input.clone(),
@@ -898,6 +927,7 @@ mod tests {
     define_pool!(POOL_ETH_1, ETHER, 100000, TOKEN1, 100000);
     define_pool!(POOL_ETH_2, ETHER, 100000, TOKEN2, 100000);
     define_pool!(POOL_WETH_0, WETH, 100000, TOKEN0, 100000);
+    define_pool!(POOL_ETH_WETH, ETHER, 100000, WETH, 100000);
 
     static ROUTE_0_1: Lazy<Route<Token, Token, TickListDataProvider>> =
         Lazy::new(|| create_route!(POOL_0_1, TOKEN0, TOKEN1));
@@ -1024,6 +1054,50 @@ mod tests {
             );
             assert_eq!(trade.input_currency().clone(), TOKEN0.clone());
             assert_eq!(trade.output_currency().clone(), ETHER.clone());
+        }
+
+        #[tokio::test]
+        async fn can_be_constructed_with_ether_as_output_for_exact_output_with_eth_weth_pool() {
+            let trade = trade_from_route!(
+                create_route!(POOL_WETH_0, POOL_ETH_WETH; TOKEN0, ETHER),
+                ETHER_AMOUNT_10000.clone(),
+                TradeType::ExactOutput
+            );
+            assert_eq!(trade.input_currency().clone(), TOKEN0.clone());
+            assert_eq!(trade.output_currency().clone(), ETHER.clone());
+        }
+
+        #[tokio::test]
+        async fn can_be_constructed_with_weth_as_output_for_exact_output_with_eth_weth_pool() {
+            let trade = trade_from_route!(
+                create_route!(POOL_ETH_0, POOL_ETH_WETH; TOKEN0, WETH),
+                currency_amount!(WETH, 10000),
+                TradeType::ExactOutput
+            );
+            assert_eq!(trade.input_currency().clone(), TOKEN0.clone());
+            assert_eq!(trade.output_currency().clone(), WETH.clone());
+        }
+
+        #[tokio::test]
+        async fn exact_output_ether_from_single_eth_weth_pool() {
+            let trade = trade_from_route!(
+                create_route!(POOL_ETH_WETH, WETH, ETHER),
+                ETHER_AMOUNT_10000.clone(),
+                TradeType::ExactOutput
+            );
+            assert_eq!(trade.input_currency().clone(), WETH.clone());
+            assert_eq!(trade.output_currency().clone(), ETHER.clone());
+        }
+
+        #[tokio::test]
+        async fn exact_output_weth_from_single_eth_weth_pool() {
+            let trade = trade_from_route!(
+                create_route!(POOL_ETH_WETH, ETHER, WETH),
+                currency_amount!(WETH, 10000),
+                TradeType::ExactOutput
+            );
+            assert_eq!(trade.input_currency().clone(), ETHER.clone());
+            assert_eq!(trade.output_currency().clone(), WETH.clone());
         }
     }
 


### PR DESCRIPTION
Align route path input and exact-output trade handling with the TypeScript SDK for ETH-WETH pools.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed route path derivation for ETH/WETH trading pairs
  * Improved exact output trade simulation when routes include native/wrapped currency conversions
  * Enhanced path currency handling for multi-pool routes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shuhuiluo/uniswap-v4-sdk-rs/pull/67?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->