### PR TITLE
feat: support UR v2.1 swap encoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-v4-sdk"
-version = "1.1.1"
+version = "1.2.0"
 edition = "2024"
 rust-version = "1.88"
 authors = ["Shuhui Luo <twitter.com/aureliano_law>"]

--- a/src/abi.rs
+++ b/src/abi.rs
@@ -75,6 +75,15 @@ sol! {
     }
 
     #[derive(Debug, Default, PartialEq, Eq)]
+    struct SwapExactInParamsV2_1 {
+        address currencyIn;
+        PathKey[] path;
+        uint256[] maxHopSlippage;
+        uint128 amountIn;
+        uint128 amountOutMinimum;
+    }
+
+    #[derive(Debug, Default, PartialEq, Eq)]
     struct SwapExactOutSingleParams {
         PoolKey poolKey;
         bool zeroForOne;
@@ -87,6 +96,15 @@ sol! {
     struct SwapExactOutParams {
         address currencyOut;
         PathKey[] path;
+        uint128 amountOut;
+        uint128 amountInMaximum;
+    }
+
+    #[derive(Debug, Default, PartialEq, Eq)]
+    struct SwapExactOutParamsV2_1 {
+        address currencyOut;
+        PathKey[] path;
+        uint256[] maxHopSlippage;
         uint128 amountOut;
         uint128 amountInMaximum;
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -31,6 +31,10 @@ pub enum Error {
     #[error("Invalid currency")]
     InvalidCurrency,
 
+    /// Thrown when decoded calldata has different action and parameter counts.
+    #[error("Mismatched action and parameter counts")]
+    MismatchedActionParams,
+
     /// Thrown when trying to simulate a swap with an unsupported hook.
     #[error("Unsupported hook")]
     UnsupportedHook,

--- a/src/utils/v4_base_actions_parser.rs
+++ b/src/utils/v4_base_actions_parser.rs
@@ -1,4 +1,4 @@
-use crate::prelude::{Actions, ActionsParams, Error};
+use crate::prelude::{Actions, ActionsParams, Error, URVersion};
 use alloc::vec::Vec;
 use alloy_primitives::Bytes;
 use alloy_sol_types::SolType;
@@ -10,12 +10,15 @@ pub struct V4RouterCall {
 }
 
 #[inline]
-pub fn parse_calldata(calldata: &Bytes) -> Result<V4RouterCall, Error> {
+pub fn parse_calldata(calldata: &Bytes, version: URVersion) -> Result<V4RouterCall, Error> {
     let ActionsParams { actions, params } =
         ActionsParams::abi_decode_params_validate(calldata.iter().as_slice())?;
+    if actions.len() != params.len() {
+        return Err(Error::MismatchedActionParams);
+    }
     Ok(V4RouterCall {
         actions: zip(actions, params)
-            .map(|(command, data)| Actions::abi_decode(command, &data))
+            .map(|(command, data)| Actions::abi_decode(command, &data, version))
             .collect::<Result<Vec<Actions>, Error>>()?,
     })
 }
@@ -25,6 +28,7 @@ mod tests {
     use super::*;
     use crate::{create_route, prelude::*, tests::*};
     use alloy_primitives::{Address, U256, address, uint};
+    use alloy_sol_types::SolValue;
     use once_cell::sync::Lazy;
     use uniswap_v3_sdk::prelude::FeeAmount;
 
@@ -47,74 +51,168 @@ mod tests {
 
     #[test]
     fn test_parse_calldata() {
-        let tests: Vec<Actions> = vec![
-            Actions::SWEEP(SweepParams {
-                currency: ADDRESS_ONE,
-                recipient: ADDRESS_TWO,
-            }),
-            Actions::CLOSE_CURRENCY(ADDRESS_ONE),
-            Actions::TAKE_PAIR(TakePairParams {
-                currency0: ADDRESS_ONE,
-                currency1: ADDRESS_TWO,
-                recipient: ADDRESS_ONE,
-            }),
-            Actions::TAKE_PORTION(TakePortionParams {
-                currency: ADDRESS_ONE,
-                recipient: ADDRESS_TWO,
-                bips: AMOUNT,
-            }),
-            Actions::TAKE_ALL(TakeAllParams {
-                currency: ADDRESS_ONE,
-                minAmount: AMOUNT,
-            }),
-            Actions::TAKE(TakeParams {
-                currency: ADDRESS_ONE,
-                recipient: ADDRESS_TWO,
-                amount: AMOUNT,
-            }),
-            Actions::SETTLE_PAIR(SettlePairParams {
-                currency0: ADDRESS_ONE,
-                currency1: ADDRESS_TWO,
-            }),
-            Actions::SETTLE(SettleParams {
-                currency: ADDRESS_ONE,
-                amount: AMOUNT,
-                payerIsUser: true,
-            }),
-            Actions::SWAP_EXACT_IN_SINGLE(SwapExactInSingleParams {
-                poolKey: USDC_WETH.pool_key.clone(),
-                zeroForOne: true,
-                amountIn: AMOUNT.try_into().unwrap(),
-                amountOutMinimum: AMOUNT.try_into().unwrap(),
-                hookData: Bytes::default(),
-            }),
-            Actions::SWAP_EXACT_OUT_SINGLE(SwapExactOutSingleParams {
-                poolKey: USDC_WETH.pool_key.clone(),
-                zeroForOne: true,
-                amountOut: AMOUNT.try_into().unwrap(),
-                amountInMaximum: AMOUNT.try_into().unwrap(),
-                hookData: Bytes::default(),
-            }),
-            Actions::SWAP_EXACT_IN(SwapExactInParams {
-                currencyIn: DAI.address,
-                path: encode_route_to_path(&create_route!(DAI_USDC, USDC_WETH; DAI, WETH), false),
-                amountIn: AMOUNT.try_into().unwrap(),
-                amountOutMinimum: AMOUNT.try_into().unwrap(),
-            }),
-            Actions::SWAP_EXACT_OUT(SwapExactOutParams {
-                currencyOut: DAI.address,
-                path: encode_route_to_path(&create_route!(DAI_USDC, USDC_WETH; DAI, WETH), false),
-                amountOut: AMOUNT.try_into().unwrap(),
-                amountInMaximum: AMOUNT.try_into().unwrap(),
-            }),
+        let route = create_route!(DAI_USDC, USDC_WETH; DAI, WETH);
+        let tests: Vec<(Actions, URVersion)> = vec![
+            (
+                Actions::SWEEP(SweepParams {
+                    currency: ADDRESS_ONE,
+                    recipient: ADDRESS_TWO,
+                }),
+                URVersion::default(),
+            ),
+            (Actions::CLOSE_CURRENCY(ADDRESS_ONE), URVersion::default()),
+            (
+                Actions::TAKE_PAIR(TakePairParams {
+                    currency0: ADDRESS_ONE,
+                    currency1: ADDRESS_TWO,
+                    recipient: ADDRESS_ONE,
+                }),
+                URVersion::default(),
+            ),
+            (
+                Actions::TAKE_PORTION(TakePortionParams {
+                    currency: ADDRESS_ONE,
+                    recipient: ADDRESS_TWO,
+                    bips: AMOUNT,
+                }),
+                URVersion::default(),
+            ),
+            (
+                Actions::TAKE_ALL(TakeAllParams {
+                    currency: ADDRESS_ONE,
+                    minAmount: AMOUNT,
+                }),
+                URVersion::default(),
+            ),
+            (
+                Actions::TAKE(TakeParams {
+                    currency: ADDRESS_ONE,
+                    recipient: ADDRESS_TWO,
+                    amount: AMOUNT,
+                }),
+                URVersion::default(),
+            ),
+            (
+                Actions::SETTLE_PAIR(SettlePairParams {
+                    currency0: ADDRESS_ONE,
+                    currency1: ADDRESS_TWO,
+                }),
+                URVersion::default(),
+            ),
+            (
+                Actions::SETTLE(SettleParams {
+                    currency: ADDRESS_ONE,
+                    amount: AMOUNT,
+                    payerIsUser: true,
+                }),
+                URVersion::default(),
+            ),
+            (
+                Actions::SWAP_EXACT_IN_SINGLE(SwapExactInSingleParams {
+                    poolKey: USDC_WETH.pool_key.clone(),
+                    zeroForOne: true,
+                    amountIn: AMOUNT.try_into().unwrap(),
+                    amountOutMinimum: AMOUNT.try_into().unwrap(),
+                    hookData: Bytes::default(),
+                }),
+                URVersion::default(),
+            ),
+            (
+                Actions::SWAP_EXACT_OUT_SINGLE(SwapExactOutSingleParams {
+                    poolKey: USDC_WETH.pool_key.clone(),
+                    zeroForOne: true,
+                    amountOut: AMOUNT.try_into().unwrap(),
+                    amountInMaximum: AMOUNT.try_into().unwrap(),
+                    hookData: Bytes::default(),
+                }),
+                URVersion::default(),
+            ),
+            (
+                Actions::SWAP_EXACT_IN(
+                    SwapExactInParams {
+                        currencyIn: DAI.address,
+                        path: encode_route_to_path(&route, false),
+                        amountIn: AMOUNT.try_into().unwrap(),
+                        amountOutMinimum: AMOUNT.try_into().unwrap(),
+                    }
+                    .into(),
+                ),
+                URVersion::V2_0,
+            ),
+            (
+                Actions::SWAP_EXACT_OUT(
+                    SwapExactOutParams {
+                        currencyOut: DAI.address,
+                        path: encode_route_to_path(&route, true),
+                        amountOut: AMOUNT.try_into().unwrap(),
+                        amountInMaximum: AMOUNT.try_into().unwrap(),
+                    }
+                    .into(),
+                ),
+                URVersion::V2_0,
+            ),
+            (
+                Actions::SWAP_EXACT_IN(
+                    SwapExactInParamsV2_1 {
+                        currencyIn: DAI.address,
+                        path: encode_route_to_path(&route, false),
+                        maxHopSlippage: vec![uint!(10000_U256), uint!(20000_U256)],
+                        amountIn: AMOUNT.try_into().unwrap(),
+                        amountOutMinimum: 0,
+                    }
+                    .into(),
+                ),
+                URVersion::V2_1,
+            ),
+            (
+                Actions::SWAP_EXACT_OUT(
+                    SwapExactOutParamsV2_1 {
+                        currencyOut: WETH.address,
+                        path: encode_route_to_path(&route, true),
+                        maxHopSlippage: vec![uint!(15000_U256), uint!(25000_U256)],
+                        amountOut: AMOUNT.try_into().unwrap(),
+                        amountInMaximum: AMOUNT.try_into().unwrap(),
+                    }
+                    .into(),
+                ),
+                URVersion::V2_1,
+            ),
+            (
+                Actions::SWAP_EXACT_IN(
+                    SwapExactInParamsV2_1 {
+                        currencyIn: DAI.address,
+                        path: encode_route_to_path(&route, false),
+                        maxHopSlippage: Vec::new(),
+                        amountIn: AMOUNT.try_into().unwrap(),
+                        amountOutMinimum: 0,
+                    }
+                    .into(),
+                ),
+                URVersion::V2_1,
+            ),
         ];
 
-        for test in tests {
+        for (test, version) in tests {
             let mut planner = V4Planner::default();
             planner.add_action(&test);
             let calldata = planner.finalize();
-            let result = parse_calldata(&calldata).unwrap();
+            let result = parse_calldata(&calldata, version).unwrap();
             assert_eq!(result.actions, vec![test]);
         }
+    }
+
+    #[test]
+    fn test_parse_calldata_rejects_mismatched_action_params() {
+        let calldata: Bytes = ActionsParams {
+            actions: vec![0x12, 0x16].into(),
+            params: vec![Address::ZERO.abi_encode().into()],
+        }
+        .abi_encode_params()
+        .into();
+
+        assert!(matches!(
+            parse_calldata(&calldata, URVersion::default()).unwrap_err(),
+            Error::MismatchedActionParams
+        ));
     }
 }

--- a/src/utils/v4_planner.rs
+++ b/src/utils/v4_planner.rs
@@ -1,8 +1,42 @@
 use crate::prelude::{Error, Trade, encode_route_to_path, *};
 use alloy_primitives::{Bytes, U256};
 use alloy_sol_types::SolValue;
+use derive_more::From;
 use uniswap_sdk_core::prelude::*;
 use uniswap_v3_sdk::prelude::*;
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum URVersion {
+    #[default]
+    V2_0,
+    V2_1,
+}
+
+#[derive(Clone, Debug, From, PartialEq)]
+pub enum SwapExactIn {
+    V2_0(SwapExactInParams),
+    V2_1(SwapExactInParamsV2_1),
+}
+
+impl Default for SwapExactIn {
+    #[inline]
+    fn default() -> Self {
+        Self::V2_0(SwapExactInParams::default())
+    }
+}
+
+#[derive(Clone, Debug, From, PartialEq)]
+pub enum SwapExactOut {
+    V2_0(SwapExactOutParams),
+    V2_1(SwapExactOutParamsV2_1),
+}
+
+impl Default for SwapExactOut {
+    #[inline]
+    fn default() -> Self {
+        Self::V2_0(SwapExactOutParams::default())
+    }
+}
 
 #[allow(non_camel_case_types)]
 #[derive(Clone, Debug, PartialEq)]
@@ -16,9 +50,9 @@ pub enum Actions {
     BURN_POSITION(BurnPositionParams) = 0x03,
     // Swapping
     SWAP_EXACT_IN_SINGLE(SwapExactInSingleParams) = 0x06,
-    SWAP_EXACT_IN(SwapExactInParams) = 0x07,
+    SWAP_EXACT_IN(SwapExactIn) = 0x07,
     SWAP_EXACT_OUT_SINGLE(SwapExactOutSingleParams) = 0x08,
-    SWAP_EXACT_OUT(SwapExactOutParams) = 0x09,
+    SWAP_EXACT_OUT(SwapExactOut) = 0x09,
 
     // Closing deltas on the pool manager
     // Settling
@@ -58,9 +92,11 @@ impl Actions {
             Self::MINT_POSITION(params) => params.abi_encode_params(),
             Self::BURN_POSITION(params) => params.abi_encode_params(),
             Self::SWAP_EXACT_IN_SINGLE(params) => params.abi_encode(),
-            Self::SWAP_EXACT_IN(params) => params.abi_encode(),
+            Self::SWAP_EXACT_IN(SwapExactIn::V2_0(params)) => params.abi_encode(),
+            Self::SWAP_EXACT_IN(SwapExactIn::V2_1(params)) => params.abi_encode(),
             Self::SWAP_EXACT_OUT_SINGLE(params) => params.abi_encode(),
-            Self::SWAP_EXACT_OUT(params) => params.abi_encode(),
+            Self::SWAP_EXACT_OUT(SwapExactOut::V2_0(params)) => params.abi_encode(),
+            Self::SWAP_EXACT_OUT(SwapExactOut::V2_1(params)) => params.abi_encode(),
             Self::SETTLE(params) => params.abi_encode_params(),
             Self::SETTLE_ALL(params) => params.abi_encode_params(),
             Self::SETTLE_PAIR(params) => params.abi_encode_params(),
@@ -76,7 +112,7 @@ impl Actions {
     }
 
     #[inline]
-    pub fn abi_decode(command: u8, data: &Bytes) -> Result<Self, Error> {
+    pub fn abi_decode(command: u8, data: &Bytes, version: URVersion) -> Result<Self, Error> {
         let data = data.iter().as_slice();
         Ok(match command {
             0x00 => {
@@ -88,11 +124,17 @@ impl Actions {
             0x02 => Self::MINT_POSITION(MintPositionParams::abi_decode_params_validate(data)?),
             0x03 => Self::BURN_POSITION(BurnPositionParams::abi_decode_params_validate(data)?),
             0x06 => Self::SWAP_EXACT_IN_SINGLE(SwapExactInSingleParams::abi_decode_validate(data)?),
-            0x07 => Self::SWAP_EXACT_IN(SwapExactInParams::abi_decode_validate(data)?),
+            0x07 => Self::SWAP_EXACT_IN(match version {
+                URVersion::V2_0 => SwapExactInParams::abi_decode_validate(data)?.into(),
+                URVersion::V2_1 => SwapExactInParamsV2_1::abi_decode_validate(data)?.into(),
+            }),
             0x08 => {
                 Self::SWAP_EXACT_OUT_SINGLE(SwapExactOutSingleParams::abi_decode_validate(data)?)
             }
-            0x09 => Self::SWAP_EXACT_OUT(SwapExactOutParams::abi_decode_validate(data)?),
+            0x09 => Self::SWAP_EXACT_OUT(match version {
+                URVersion::V2_0 => SwapExactOutParams::abi_decode_validate(data)?.into(),
+                URVersion::V2_1 => SwapExactOutParamsV2_1::abi_decode_validate(data)?.into(),
+            }),
             0x0b => Self::SETTLE(SettleParams::abi_decode_params_validate(data)?),
             0x0c => Self::SETTLE_ALL(SettleAllParams::abi_decode_params_validate(data)?),
             0x0d => Self::SETTLE_PAIR(SettlePairParams::abi_decode_params_validate(data)?),
@@ -127,6 +169,8 @@ impl V4Planner {
         &mut self,
         trade: &Trade<TInput, TOutput, TP>,
         slippage_tolerance: Option<Percent>,
+        max_hop_slippage: Option<Vec<U256>>,
+        version: URVersion,
     ) -> Result<&mut Self, Error>
     where
         TInput: BaseCurrency,
@@ -149,39 +193,75 @@ impl V4Planner {
         );
 
         let route = trade.route();
-        let currency_in = currency_address(&route.path_input);
-        let currency_out = currency_address(&route.path_output);
         let path = encode_route_to_path(route, exact_output);
+        let max_hop_slippage = max_hop_slippage.unwrap_or_default();
 
-        Ok(self.add_action(
-            &(if exact_output {
-                Actions::SWAP_EXACT_OUT(SwapExactOutParams {
-                    currencyOut: currency_out,
-                    path,
-                    amountOut: trade.output_amount()?.quotient().to_u128().unwrap(),
-                    amountInMaximum: trade
-                        .maximum_amount_in(slippage_tolerance.unwrap_or_default(), None)?
-                        .quotient()
-                        .to_u128()
-                        .unwrap(),
-                })
+        let action = if exact_output {
+            let currency_out = currency_address(&route.path_output);
+            let amount_out = trade.output_amount()?.quotient().to_u128().unwrap();
+            let amount_in_maximum = trade
+                .maximum_amount_in(slippage_tolerance.unwrap_or_default(), None)?
+                .quotient()
+                .to_u128()
+                .unwrap();
+
+            match version {
+                URVersion::V2_0 => Actions::SWAP_EXACT_OUT(
+                    SwapExactOutParams {
+                        currencyOut: currency_out,
+                        path,
+                        amountOut: amount_out,
+                        amountInMaximum: amount_in_maximum,
+                    }
+                    .into(),
+                ),
+                URVersion::V2_1 => Actions::SWAP_EXACT_OUT(
+                    SwapExactOutParamsV2_1 {
+                        currencyOut: currency_out,
+                        path,
+                        maxHopSlippage: max_hop_slippage,
+                        amountOut: amount_out,
+                        amountInMaximum: amount_in_maximum,
+                    }
+                    .into(),
+                ),
+            }
+        } else {
+            let currency_in = currency_address(&route.path_input);
+            let amount_in = trade.input_amount()?.quotient().to_u128().unwrap();
+            let amount_out_minimum = if let Some(slippage_tolerance) = slippage_tolerance {
+                trade
+                    .minimum_amount_out(slippage_tolerance, None)?
+                    .quotient()
+                    .to_u128()
+                    .unwrap()
             } else {
-                Actions::SWAP_EXACT_IN(SwapExactInParams {
-                    currencyIn: currency_in,
-                    path,
-                    amountIn: trade.input_amount()?.quotient().to_u128().unwrap(),
-                    amountOutMinimum: if let Some(slippage_tolerance) = slippage_tolerance {
-                        trade
-                            .minimum_amount_out(slippage_tolerance, None)?
-                            .quotient()
-                            .to_u128()
-                            .unwrap()
-                    } else {
-                        0
-                    },
-                })
-            }),
-        ))
+                0
+            };
+
+            match version {
+                URVersion::V2_0 => Actions::SWAP_EXACT_IN(
+                    SwapExactInParams {
+                        currencyIn: currency_in,
+                        path,
+                        amountIn: amount_in,
+                        amountOutMinimum: amount_out_minimum,
+                    }
+                    .into(),
+                ),
+                URVersion::V2_1 => Actions::SWAP_EXACT_IN(
+                    SwapExactInParamsV2_1 {
+                        currencyIn: currency_in,
+                        path,
+                        maxHopSlippage: max_hop_slippage,
+                        amountIn: amount_in,
+                        amountOutMinimum: amount_out_minimum,
+                    }
+                    .into(),
+                ),
+            }
+        };
+        Ok(self.add_action(&action))
     }
 
     #[inline]
@@ -240,6 +320,7 @@ fn currency_address(currency: &impl BaseCurrency) -> Address {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::create_route;
     use crate::{prelude::Pool, tests::*};
     use alloy_primitives::{hex, uint};
     use once_cell::sync::Lazy;
@@ -336,21 +417,77 @@ mod tests {
         assert_eq!(discriminant(&Actions::UNWRAP(U256::ZERO)), 0x16);
     }
 
-    #[test]
-    fn test_add_action_encode_v4_exact_in_single_swap() {
-        let mut planner = V4Planner::default();
-        planner.add_action(&Actions::SWAP_EXACT_IN_SINGLE(SwapExactInSingleParams {
-            poolKey: USDC_WETH.pool_key.clone(),
-            zeroForOne: true,
-            amountIn: ONE_ETHER,
-            amountOutMinimum: ONE_ETHER / 2,
-            hookData: Bytes::default(),
-        }));
-        assert_eq!(planner.actions, vec![0x06]);
-        assert_eq!(
+    mod add_action {
+        use super::*;
+
+        #[test]
+        fn encode_v4_exact_in_single_swap() {
+            let mut planner = V4Planner::default();
+            planner.add_action(&Actions::SWAP_EXACT_IN_SINGLE(SwapExactInSingleParams {
+                poolKey: USDC_WETH.pool_key.clone(),
+                zeroForOne: true,
+                amountIn: ONE_ETHER,
+                amountOutMinimum: ONE_ETHER / 2,
+                hookData: Bytes::default(),
+            }));
+            assert_eq!(planner.actions, vec![0x06]);
+            assert_eq!(
             planner.params[0],
             hex!("0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc20000000000000000000000000000000000000000000000000000000000000bb8000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000de0b6b3a764000000000000000000000000000000000000000000000000000006f05b59d3b2000000000000000000000000000000000000000000000000000000000000000001200000000000000000000000000000000000000000000000000000000000000000").to_vec()
         );
+        }
+
+        #[test]
+        fn encode_v4_exact_in_swap_v2_1() {
+            let route = create_route!(DAI_USDC, USDC_WETH; DAI, WETH);
+            let max_hop_slippage = vec![uint!(10000_U256), uint!(20000_U256)];
+            let mut planner = V4Planner::default();
+
+            planner.add_action(&Actions::SWAP_EXACT_IN(
+                SwapExactInParamsV2_1 {
+                    currencyIn: DAI.address,
+                    path: encode_route_to_path(&route, false),
+                    maxHopSlippage: max_hop_slippage.clone(),
+                    amountIn: ONE_ETHER,
+                    amountOutMinimum: 0,
+                }
+                .into(),
+            ));
+
+            assert_eq!(planner.actions, vec![0x07]);
+            let decoded =
+                SwapExactInParamsV2_1::abi_decode_validate(planner.params[0].iter().as_slice())
+                    .unwrap();
+            assert_eq!(decoded.currencyIn, DAI.address);
+            assert_eq!(decoded.maxHopSlippage, max_hop_slippage);
+            assert_eq!(decoded.amountIn, ONE_ETHER);
+        }
+
+        #[test]
+        fn encode_v4_exact_out_swap_v2_1() {
+            let route = create_route!(DAI_USDC, USDC_WETH; DAI, WETH);
+            let max_hop_slippage = vec![uint!(15000_U256), uint!(25000_U256)];
+            let mut planner = V4Planner::default();
+
+            planner.add_action(&Actions::SWAP_EXACT_OUT(
+                SwapExactOutParamsV2_1 {
+                    currencyOut: WETH.address,
+                    path: encode_route_to_path(&route, true),
+                    maxHopSlippage: max_hop_slippage.clone(),
+                    amountOut: ONE_ETHER,
+                    amountInMaximum: 2 * ONE_ETHER,
+                }
+                .into(),
+            ));
+
+            assert_eq!(planner.actions, vec![0x09]);
+            let decoded =
+                SwapExactOutParamsV2_1::abi_decode_validate(planner.params[0].iter().as_slice())
+                    .unwrap();
+            assert_eq!(decoded.currencyOut, WETH.address);
+            assert_eq!(decoded.maxHopSlippage, max_hop_slippage);
+            assert_eq!(decoded.amountOut, ONE_ETHER);
+        }
     }
 
     mod add_settle {
@@ -442,7 +579,7 @@ mod tests {
 
     mod add_trade {
         use super::*;
-        use crate::{create_route, currency_amount, trade_from_route};
+        use crate::{currency_amount, trade_from_route};
 
         #[tokio::test]
         async fn completes_v4_exact_in_2_hop_swap_same_results_as_add_action() {
@@ -450,12 +587,15 @@ mod tests {
 
             // encode with addAction function
             let mut planner = V4Planner::default();
-            planner.add_action(&Actions::SWAP_EXACT_IN(SwapExactInParams {
-                currencyIn: DAI.address,
-                path: encode_route_to_path(&route, false),
-                amountIn: ONE_ETHER,
-                amountOutMinimum: 0,
-            }));
+            planner.add_action(&Actions::SWAP_EXACT_IN(
+                SwapExactInParams {
+                    currencyIn: DAI.address,
+                    path: encode_route_to_path(&route, false),
+                    amountIn: ONE_ETHER,
+                    amountOutMinimum: 0,
+                }
+                .into(),
+            ));
 
             // encode with addTrade function
             let trade = trade_from_route!(
@@ -464,7 +604,9 @@ mod tests {
                 TradeType::ExactInput
             );
             let mut trade_planner = V4Planner::default();
-            trade_planner.add_trade(&trade, None).unwrap();
+            trade_planner
+                .add_trade(&trade, None, None, URVersion::default())
+                .unwrap();
 
             assert_eq!(planner.actions, vec![0x07]);
             assert_eq!(
@@ -473,6 +615,29 @@ mod tests {
             );
             assert_eq!(planner.actions, trade_planner.actions);
             assert_eq!(planner.params[0], trade_planner.params[0]);
+        }
+
+        #[tokio::test]
+        async fn completes_v4_exact_in_2_hop_swap_v2_0_without_max_hop_slippage() {
+            let route = create_route!(DAI_USDC, USDC_WETH; DAI, WETH);
+            let trade = trade_from_route!(
+                route,
+                currency_amount!(DAI, ONE_ETHER),
+                TradeType::ExactInput
+            );
+            let mut planner = V4Planner::default();
+
+            planner
+                .add_trade(&trade, None, None, URVersion::default())
+                .unwrap();
+
+            assert_eq!(planner.actions, vec![0x07]);
+            let decoded =
+                SwapExactInParams::abi_decode_validate(planner.params[0].iter().as_slice())
+                    .unwrap();
+            assert_eq!(decoded.currencyIn, DAI.address);
+            // The V2.0 ABI type has no maxHopSlippage field.
+            assert_eq!(decoded.amountIn, ONE_ETHER);
         }
 
         #[tokio::test]
@@ -485,9 +650,14 @@ mod tests {
                 TradeType::ExactOutput
             );
             let mut planner = V4Planner::default();
-            planner.add_trade(&trade, Some(slippage_tolerance)).unwrap();
+            planner
+                .add_trade(&trade, Some(slippage_tolerance), None, URVersion::default())
+                .unwrap();
 
             assert_eq!(planner.actions, vec![0x09]);
+            let _decoded =
+                SwapExactOutParams::abi_decode_validate(planner.params[0].iter().as_slice())
+                    .unwrap();
             assert_eq!(
                 planner.params[0],
                 hex!("0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc200000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000de0b6b3a76400000000000000000000000000000000000000000000000000000ea8d524a2a4ae240000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000001000000000000000000000000006b175474e89094c44da98b954eedeac495271d0f0000000000000000000000000000000000000000000000000000000000000bb8000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb480000000000000000000000000000000000000000000000000000000000000bb8000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000").to_vec()
@@ -504,9 +674,14 @@ mod tests {
                 TradeType::ExactOutput
             );
             let mut planner = V4Planner::default();
-            planner.add_trade(&trade, Some(slippage_tolerance)).unwrap();
+            planner
+                .add_trade(&trade, Some(slippage_tolerance), None, URVersion::default())
+                .unwrap();
 
             assert_eq!(planner.actions, vec![0x09]);
+            let _decoded =
+                SwapExactOutParams::abi_decode_validate(planner.params[0].iter().as_slice())
+                    .unwrap();
             assert_eq!(
                 planner.params[0],
                 hex!("0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc200000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000de0b6b3a76400000000000000000000000000000000000000000000000000000ea8d524a2a4ae240000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000001000000000000000000000000006b175474e89094c44da98b954eedeac495271d0f0000000000000000000000000000000000000000000000000000000000000bb8000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb480000000000000000000000000000000000000000000000000000000000000bb8000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000").to_vec()
@@ -523,9 +698,14 @@ mod tests {
                 TradeType::ExactInput
             );
             let mut planner = V4Planner::default();
-            planner.add_trade(&trade, Some(slippage_tolerance)).unwrap();
+            planner
+                .add_trade(&trade, Some(slippage_tolerance), None, URVersion::default())
+                .unwrap();
 
             assert_eq!(planner.actions, vec![0x07]);
+            let _decoded =
+                SwapExactInParams::abi_decode_validate(planner.params[0].iter().as_slice())
+                    .unwrap();
             assert_eq!(
                 planner.params[0],
                 hex!("0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc200000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000de0b6b3a76400000000000000000000000000000000000000000000000000000d23441c93fad7ca000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000100000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb480000000000000000000000000000000000000000000000000000000000000bb8000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000000000000000000000000000006b175474e89094c44da98b954eedeac495271d0f0000000000000000000000000000000000000000000000000000000000000bb8000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000").to_vec()
@@ -541,7 +721,9 @@ mod tests {
                 currency_amount!(WETH, ONE_ETHER),
                 TradeType::ExactOutput
             );
-            V4Planner::default().add_trade(&trade, None).unwrap();
+            V4Planner::default()
+                .add_trade(&trade, None, None, URVersion::default())
+                .unwrap();
         }
 
         #[tokio::test]
@@ -560,8 +742,87 @@ mod tests {
             .await
             .unwrap();
             V4Planner::default()
-                .add_trade(&trade, Some(slippage_tolerance))
+                .add_trade(&trade, Some(slippage_tolerance), None, URVersion::default())
                 .unwrap();
+        }
+
+        #[tokio::test]
+        async fn completes_v4_exact_in_2_hop_swap_with_max_hop_slippage_v2_1() {
+            let route = create_route!(DAI_USDC, USDC_WETH; DAI, WETH);
+            let trade = trade_from_route!(
+                route,
+                currency_amount!(DAI, ONE_ETHER),
+                TradeType::ExactInput
+            );
+            let max_hop_slippage = vec![uint!(10000_U256), uint!(20000_U256)];
+            let mut planner = V4Planner::default();
+
+            planner
+                .add_trade(
+                    &trade,
+                    None,
+                    Some(max_hop_slippage.clone()),
+                    URVersion::V2_1,
+                )
+                .unwrap();
+
+            assert_eq!(planner.actions, vec![0x07]);
+            let decoded =
+                SwapExactInParamsV2_1::abi_decode_validate(planner.params[0].iter().as_slice())
+                    .unwrap();
+            assert_eq!(decoded.currencyIn, DAI.address);
+            assert_eq!(decoded.maxHopSlippage, max_hop_slippage);
+        }
+
+        #[tokio::test]
+        async fn completes_v4_exact_out_2_hop_swap_with_max_hop_slippage_v2_1() {
+            let route = create_route!(DAI_USDC, USDC_WETH; DAI, WETH);
+            let slippage_tolerance = Percent::new(5, 100);
+            let trade = trade_from_route!(
+                route,
+                currency_amount!(WETH, ONE_ETHER),
+                TradeType::ExactOutput
+            );
+            let max_hop_slippage = vec![uint!(10000_U256), uint!(20000_U256)];
+            let mut planner = V4Planner::default();
+
+            planner
+                .add_trade(
+                    &trade,
+                    Some(slippage_tolerance),
+                    Some(max_hop_slippage.clone()),
+                    URVersion::V2_1,
+                )
+                .unwrap();
+
+            assert_eq!(planner.actions, vec![0x09]);
+            let decoded =
+                SwapExactOutParamsV2_1::abi_decode_validate(planner.params[0].iter().as_slice())
+                    .unwrap();
+            assert_eq!(decoded.currencyOut, WETH.address);
+            assert_eq!(decoded.maxHopSlippage, max_hop_slippage);
+        }
+
+        #[tokio::test]
+        async fn completes_v4_exact_in_swap_with_empty_max_hop_slippage_v2_1() {
+            let route = create_route!(DAI_USDC, USDC_WETH; DAI, WETH);
+            let trade = trade_from_route!(
+                route,
+                currency_amount!(DAI, ONE_ETHER),
+                TradeType::ExactInput
+            );
+            let mut planner = V4Planner::default();
+
+            planner
+                .add_trade(&trade, None, None, URVersion::V2_1)
+                .unwrap();
+
+            assert_eq!(planner.actions, vec![0x07]);
+            let decoded =
+                SwapExactInParamsV2_1::abi_decode_validate(planner.params[0].iter().as_slice())
+                    .unwrap();
+            assert_eq!(decoded.currencyIn, DAI.address);
+            assert!(decoded.maxHopSlippage.is_empty());
         }
     }
 }


### PR DESCRIPTION
Add versioned exact-in/out swap ABI variants with max hop slippage and route add_trade through URVersion.

Update planner and parser tests for V2.0 defaults and V2.1 calldata round trips.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for v2.1 Universal Router with per-hop maximum slippage control, enabling more granular risk management for multi-hop swaps
  * Enhanced compatibility to support both v2.0 and v2.1 routing standards, providing flexibility across different swap execution strategies

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shuhuiluo/uniswap-v4-sdk-rs/pull/68?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->