### PR TITLE
feat: add URVersion::V2_2_0; bump uniswap-v3-sdk to 6.2.0, v1.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-v4-sdk"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2024"
 rust-version = "1.88"
 authors = ["Shuhui Luo <twitter.com/aureliano_law>"]
@@ -24,10 +24,10 @@ derive_more = { version = "2", default-features = false, features = ["deref", "d
 thiserror = { version = "2", default-features = false }
 tokio = { version = "1.47", optional = true, default-features = false, features = ["macros"] }
 uniswap-sdk-core = "6.0.0"
-uniswap-v3-sdk = "6.1.0"
+uniswap-v3-sdk = "6.2.0"
 
 [dev-dependencies]
-alloy = { version = "1.0.23", default-features = false, features = ["provider-anvil-node", "reqwest-rustls-tls", "signer-local"] }
+alloy = { version = "1.1", default-features = false, features = ["provider-anvil-node", "reqwest-rustls-tls", "signer-local"] }
 dotenv = "0.15"
 num-integer = { version = "0.1", default-features = false }
 num-traits = { version = "0.2", default-features = false }

--- a/src/utils/v4_planner.rs
+++ b/src/utils/v4_planner.rs
@@ -10,11 +10,12 @@ pub enum URVersion {
     #[default]
     V2_0,
     V2_1_1,
+    V2_2_0,
 }
 
 #[inline]
 const fn is_v2_1_1_or_later(v: URVersion) -> bool {
-    matches!(v, URVersion::V2_1_1)
+    matches!(v, URVersion::V2_1_1 | URVersion::V2_2_0)
 }
 
 #[derive(Clone, Debug, From, PartialEq)]
@@ -264,7 +265,7 @@ impl V4Planner {
                     }
                     .into(),
                 ),
-                URVersion::V2_1_1 => Actions::SWAP_EXACT_OUT(
+                URVersion::V2_1_1 | URVersion::V2_2_0 => Actions::SWAP_EXACT_OUT(
                     SwapExactOutParamsV2_1_1 {
                         currencyOut: currency_out,
                         path,
@@ -298,7 +299,7 @@ impl V4Planner {
                     }
                     .into(),
                 ),
-                URVersion::V2_1_1 => Actions::SWAP_EXACT_IN(
+                URVersion::V2_1_1 | URVersion::V2_2_0 => Actions::SWAP_EXACT_IN(
                     SwapExactInParamsV2_1_1 {
                         currencyIn: currency_in,
                         path,


### PR DESCRIPTION
Port TS commit 9e965894. V2_2_0 reuses the V2.1.1 ABI so no struct changes are needed — only the version enum and is_v2_1_1_or_later predicate are updated.